### PR TITLE
fix: align contributor test setup with current main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing
+
+Thanks for contributing to Ogham MCP.
+
+Keep changes small, focused, and easy to review. Bug fixes, tests, docs, and
+small usability improvements are all good contributions. For larger changes,
+open an issue or discussion first so the approach is aligned before you spend
+time implementing it.
+
+## What to contribute
+
+- bug fixes
+- tests that protect real regressions
+- documentation improvements
+- small, well-scoped developer experience improvements
+
+## Local setup
+
+```bash
+git clone https://github.com/ogham-mcp/ogham-mcp.git
+cd ogham-mcp
+uv sync
+```
+
+## Validation
+
+For the local non-integration test suite, use a placeholder `SUPABASE_URL` if
+you have not configured a real backend yet. Some modules validate settings at
+import time during test collection.
+
+```bash
+uv run ruff check src tests
+
+SUPABASE_URL=https://fake.supabase.co \
+  uv run pytest tests -m 'not integration and not postgres_integration' -q
+```
+
+Integration suites stay separate:
+
+```bash
+uv run pytest tests/test_integration.py -v
+
+DATABASE_BACKEND=postgres DATABASE_URL="postgres://..." \
+  uv run pytest tests/test_postgres_integration.py -v
+```
+
+## Pull requests
+
+- Keep the branch and PR focused on one change.
+- Explain what changed and why.
+- Include the validation commands you ran.
+- If the change affects behavior, add or update tests with it.

--- a/tests/test_migration_integrity.py
+++ b/tests/test_migration_integrity.py
@@ -29,26 +29,33 @@ def test_no_unnumbered_migrations():
     )
 
 
-def test_no_file_sorts_after_017():
-    """No migration may sort alphabetically after 017_rrf_bm25.sql.
+def test_later_hybrid_search_migrations_preserve_rrf():
+    """Later migrations may evolve hybrid search, but must keep true RRF.
 
-    017 is the RRF fix. If anything alphabetically-later re-defines
-    hybrid_search_memories, it will overwrite the fix on every upgrade.
+    017 introduced the v0.9.2 RRF fix. Later migrations such as 021 may
+    legitimately re-define hybrid_search_memories, but they must preserve
+    the position-based RRF formula rather than silently reintroducing the
+    older raw-score fusion regression.
     """
     migrations = _top_level_migrations()
     rrf_fix = next((p for p in migrations if p.name == "017_rrf_bm25.sql"), None)
     assert rrf_fix is not None, "expected 017_rrf_bm25.sql at top-level sql/migrations/"
 
     later = [p.name for p in migrations if p.name > rrf_fix.name]
-    hybrid_offenders = [
-        name
-        for name in later
-        if "hybrid_search_memories" in (MIGRATIONS_DIR / name).read_text().lower()
-    ]
-    assert not hybrid_offenders, (
-        f"Migration(s) sorting after 017_rrf_bm25.sql redefine hybrid_search_memories "
-        f"and will overwrite the RRF fix: {hybrid_offenders}"
-    )
+    broken_pattern = "semantic_weight * coalesce(s.similarity"
+
+    for name in later:
+        content = (MIGRATIONS_DIR / name).read_text().lower()
+        if "create or replace function hybrid_search_memories" not in content:
+            continue
+        assert "1.0 / (rrf_k + coalesce(" in content, (
+            f"{name} redefines hybrid_search_memories but does not preserve "
+            "the true Reciprocal Rank Fusion formula"
+        )
+        assert broken_pattern not in content, (
+            f"{name} redefines hybrid_search_memories with the broken raw-score "
+            "fusion pattern"
+        )
 
 
 def test_017_rrf_bm25_is_functional_and_uses_rrf():

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -40,6 +40,7 @@ def mock_db():
         patch("ogham.service.db_store") as store,
         patch("ogham.service.hybrid_search_memories") as search,
         patch("ogham.service.record_access") as rec_access,
+        patch("ogham.tools.memory.record_access", new=rec_access),
         patch("ogham.service.db_get_profile_ttl") as get_ttl,
         patch("ogham.service.db_auto_link") as auto_link,
         patch("ogham.tools.memory.list_recent_memories") as list_recent,


### PR DESCRIPTION
## Problem

Current `main` trips contributors in the non-integration test path for three small reasons:

- the migration integrity guard rejects later `hybrid_search_memories` redefinitions even when they preserve true RRF
- `explore_knowledge` tests patch `record_access` in the wrong module, so the call can escape the mock and reach the backend
- the local non-integration test command needs a placeholder `SUPABASE_URL`, but that setup was undocumented

## Fix

- update the migration integrity test to allow later redefinitions that preserve the canonical RRF formula
- patch `record_access` where `explore_knowledge` actually calls it
- add `CONTRIBUTING.md` with local setup and the placeholder `SUPABASE_URL` needed for the non-integration test run

## Validation

- `env UV_CACHE_DIR=/tmp/uv-cache uv run ruff check src tests`
- `SUPABASE_URL=https://fake.supabase.co uv run pytest tests -m 'not integration and not postgres_integration' -q`

Result: `422 passed, 31 deselected`
