### PR TITLE
feat: add profile health signals to stats

### DIFF
--- a/src/ogham/cli.py
+++ b/src/ogham/cli.py
@@ -152,13 +152,26 @@ def profiles():
 def stats(profile: str = typer.Option(None, help="Profile to show stats for")):
     """Show statistics for a memory profile."""
     from ogham.config import settings
-    from ogham.database import get_memory_stats
+    from ogham.database import (
+        count_decay_eligible,
+        count_expired,
+        get_memory_stats,
+        get_profile_ttl,
+    )
 
     target = profile or settings.default_profile
-    data = get_memory_stats(profile=target)
+    data = dict(get_memory_stats(profile=target))
+    data["ttl_days"] = get_profile_ttl(target)
+    data["expired_count"] = count_expired(target)
+    data["decay_eligible"] = count_decay_eligible(target)
 
     console.print(f"\n[bold]Profile:[/bold] {data.get('profile', target)}")
     console.print(f"[bold]Total memories:[/bold] {data.get('total', 0)}")
+    ttl_days = data.get("ttl_days")
+    ttl_display = "disabled" if ttl_days is None else f"{ttl_days} days"
+    console.print(f"[bold]TTL:[/bold] {ttl_display}")
+    console.print(f"[bold]Expired memories:[/bold] {data.get('expired_count', 0)}")
+    console.print(f"[bold]Decay eligible:[/bold] {data.get('decay_eligible', 0)}")
 
     sources = data.get("sources") or {}
     if sources:

--- a/src/ogham/tools/stats.py
+++ b/src/ogham/tools/stats.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Any
 
 from ogham.app import mcp
-from ogham.database import get_memory_stats
+from ogham.database import count_decay_eligible, count_expired, get_memory_stats, get_profile_ttl
 from ogham.embeddings import get_cache_stats as _get_cache_stats
 from ogham.tools.memory import get_active_profile
 
@@ -109,9 +109,15 @@ def get_config() -> dict[str, Any]:
 def get_stats() -> dict[str, Any]:
     """Get summary statistics for the active memory profile.
 
-    Returns total count, source breakdown, and top tags.
+    Returns total count, source breakdown, top tags, TTL, expired count,
+    and Hebbian decay eligibility.
     """
-    return get_memory_stats(profile=get_active_profile())
+    profile = get_active_profile()
+    stats = dict(get_memory_stats(profile=profile))
+    stats["ttl_days"] = get_profile_ttl(profile)
+    stats["expired_count"] = count_expired(profile)
+    stats["decay_eligible"] = count_decay_eligible(profile)
+    return stats
 
 
 @mcp.tool

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,17 +50,28 @@ def test_cli_stats():
     """ogham stats should show profile stats"""
     from ogham.cli import app
 
-    with patch("ogham.database.get_memory_stats") as mock_stats:
+    with (
+        patch("ogham.database.get_memory_stats") as mock_stats,
+        patch("ogham.database.get_profile_ttl") as mock_ttl,
+        patch("ogham.database.count_expired") as mock_expired,
+        patch("ogham.database.count_decay_eligible") as mock_decay,
+    ):
         mock_stats.return_value = {
             "profile": "default",
             "total": 42,
             "sources": {"claude-code": 30},
             "top_tags": [{"tag": "project:foo", "count": 10}],
         }
+        mock_ttl.return_value = 30
+        mock_expired.return_value = 3
+        mock_decay.return_value = 5
         result = runner.invoke(app, ["stats"])
 
     assert result.exit_code == 0
     assert "42" in result.output
+    assert "30 days" in result.output
+    assert "3" in result.output
+    assert "5" in result.output
 
 
 def test_cli_search():

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -686,6 +686,35 @@ def test_get_cache_stats_tool():
     assert result["hit_rate"] == 0.0
 
 
+def test_get_stats_tool_includes_profile_health():
+    """get_stats should include TTL, expired count, and decay eligibility."""
+    from ogham.tools.stats import get_stats
+
+    with (
+        patch("ogham.tools.stats.get_memory_stats") as mock_stats,
+        patch("ogham.tools.stats.get_profile_ttl") as mock_ttl,
+        patch("ogham.tools.stats.count_expired") as mock_expired,
+        patch("ogham.tools.stats.count_decay_eligible") as mock_decay,
+    ):
+        mock_stats.return_value = {
+            "profile": "default",
+            "total": 42,
+            "sources": {"claude-code": 30},
+            "top_tags": [{"tag": "project:foo", "count": 10}],
+        }
+        mock_ttl.return_value = 90
+        mock_expired.return_value = 2
+        mock_decay.return_value = 7
+
+        result = get_stats()
+
+    assert result["profile"] == "default"
+    assert result["total"] == 42
+    assert result["ttl_days"] == 90
+    assert result["expired_count"] == 2
+    assert result["decay_eligible"] == 7
+
+
 # --- Expiration database tests ---
 
 


### PR DESCRIPTION
## Summary

Warm-up for the observability work.

Adds existing profile health signals to `get_stats()` and `ogham stats`:
- `ttl_days`
- `expired_count`
- `decay_eligible`

## Scope

Warm-up only. This PR stays in the existing stats surface:
- no new deps
- no schema changes
- no config changes
- no audit-path changes

## Validation

- `uv run pytest tests/test_cli.py tests/test_tools.py -q`
- `uv run ruff check src/ogham/tools/stats.py src/ogham/cli.py tests/test_cli.py tests/test_tools.py`

`86 passed`
