### PR TITLE
feat: enrich stats with profile health signals

### DIFF
--- a/src/ogham/cli.py
+++ b/src/ogham/cli.py
@@ -153,22 +153,35 @@ def stats(profile: str = typer.Option(None, help="Profile to show stats for")):
     """Show statistics for a memory profile."""
     from ogham.config import settings
     from ogham.database import get_memory_stats
+    from ogham.tools.stats import enrich_stats
 
     target = profile or settings.default_profile
-    data = get_memory_stats(profile=target)
+    data = enrich_stats(target, get_memory_stats(profile=target))
 
     console.print(f"\n[bold]Profile:[/bold] {data.get('profile', target)}")
     console.print(f"[bold]Total memories:[/bold] {data.get('total', 0)}")
+    orphan_count = data.get("orphan_count")
+    orphan_display = "unavailable" if orphan_count is None else str(orphan_count)
+    console.print(f"[bold]Orphan memories:[/bold] {orphan_display}")
+    console.print(f"[bold]Decay eligible:[/bold] {data.get('decay_eligible', 0)}")
 
     sources = data.get("sources") or {}
     if sources:
         source_str = ", ".join(f"{k}: {v}" for k, v in sources.items())
         console.print(f"[bold]Sources:[/bold] {source_str}")
 
-    top_tags = data.get("top_tags") or []
-    if top_tags:
-        tag_str = ", ".join(f"{t['tag']} ({t['count']})" for t in top_tags[:10])
-        console.print(f"[bold]Top tags:[/bold] {tag_str}")
+    tag_distribution = data.get("tag_distribution") or []
+    if tag_distribution:
+        tag_str = ", ".join(
+            f"{item['tag']} ({item['count']}, {item['share']:.0%})"
+            for item in tag_distribution[:10]
+        )
+        console.print(f"[bold]Tag distribution:[/bold] {tag_str}")
+    else:
+        top_tags = data.get("top_tags") or []
+        if top_tags:
+            tag_str = ", ".join(f"{t['tag']} ({t['count']})" for t in top_tags[:10])
+            console.print(f"[bold]Top tags:[/bold] {tag_str}")
 
     console.print()
 

--- a/src/ogham/tools/stats.py
+++ b/src/ogham/tools/stats.py
@@ -3,7 +3,12 @@ from pathlib import Path
 from typing import Any
 
 from ogham.app import mcp
-from ogham.database import get_memory_stats
+from ogham.database import (
+    count_decay_eligible,
+    get_all_memories_full,
+    get_memory_stats,
+    get_related_memories,
+)
 from ogham.embeddings import get_cache_stats as _get_cache_stats
 from ogham.tools.memory import get_active_profile
 
@@ -105,13 +110,53 @@ def get_config() -> dict[str, Any]:
     return get_runtime_config()
 
 
+def _build_tag_distribution(stats: dict[str, Any]) -> list[dict[str, Any]]:
+    total = stats.get("total")
+    if not isinstance(total, int) or total <= 0:
+        return []
+
+    distribution: list[dict[str, Any]] = []
+    for item in stats.get("top_tags") or []:
+        tag = item.get("tag")
+        count = item.get("count")
+        if not tag or not isinstance(count, int):
+            continue
+        distribution.append({"tag": tag, "count": count, "share": count / total})
+    return distribution
+
+
+def _count_orphan_memories(profile: str) -> int | None:
+    try:
+        memories = get_all_memories_full(profile)
+        orphan_count = 0
+        for memory in memories:
+            memory_id = memory.get("id")
+            if not memory_id:
+                continue
+            if not get_related_memories(memory_id=memory_id, limit=1):
+                orphan_count += 1
+        return orphan_count
+    except Exception:
+        return None
+
+
+def enrich_stats(profile: str, stats: dict[str, Any]) -> dict[str, Any]:
+    stats = dict(stats)
+    stats["decay_eligible"] = count_decay_eligible(profile)
+    stats["orphan_count"] = _count_orphan_memories(profile)
+    stats["tag_distribution"] = _build_tag_distribution(stats)
+    return stats
+
+
 @mcp.tool
 def get_stats() -> dict[str, Any]:
     """Get summary statistics for the active memory profile.
 
-    Returns total count, source breakdown, and top tags.
+    Returns total count, source breakdown, top tags, tag distribution,
+    orphan count, and Hebbian decay eligibility.
     """
-    return get_memory_stats(profile=get_active_profile())
+    profile = get_active_profile()
+    return enrich_stats(profile, get_memory_stats(profile=profile))
 
 
 @mcp.tool

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,17 +50,32 @@ def test_cli_stats():
     """ogham stats should show profile stats"""
     from ogham.cli import app
 
-    with patch("ogham.database.get_memory_stats") as mock_stats:
+    with (
+        patch("ogham.database.get_memory_stats") as mock_stats,
+        patch("ogham.tools.stats.enrich_stats") as mock_enrich,
+    ):
         mock_stats.return_value = {
             "profile": "default",
             "total": 42,
             "sources": {"claude-code": 30},
             "top_tags": [{"tag": "project:foo", "count": 10}],
         }
+        mock_enrich.return_value = {
+            "profile": "default",
+            "total": 42,
+            "orphan_count": 4,
+            "decay_eligible": 5,
+            "sources": {"claude-code": 30},
+            "top_tags": [{"tag": "project:foo", "count": 10}],
+            "tag_distribution": [{"tag": "project:foo", "count": 10, "share": 10 / 42}],
+        }
         result = runner.invoke(app, ["stats"])
 
     assert result.exit_code == 0
     assert "42" in result.output
+    assert "4" in result.output
+    assert "5" in result.output
+    assert "project:foo (10, 24%)" in result.output
 
 
 def test_cli_search():

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -686,6 +686,73 @@ def test_get_cache_stats_tool():
     assert result["hit_rate"] == 0.0
 
 
+def test_get_stats_tool_includes_profile_health():
+    """get_stats should include orphan count, tag distribution, and decay eligibility."""
+    from ogham.tools.stats import get_stats
+
+    with (
+        patch("ogham.tools.stats.get_memory_stats") as mock_base_stats,
+        patch("ogham.tools.stats.enrich_stats") as mock_stats,
+    ):
+        mock_base_stats.return_value = {
+            "profile": "default",
+            "total": 42,
+        }
+        mock_stats.return_value = {
+            "profile": "default",
+            "total": 42,
+            "orphan_count": 3,
+            "decay_eligible": 7,
+            "tag_distribution": [{"tag": "project:foo", "count": 10, "share": 10 / 42}],
+        }
+
+        result = get_stats()
+
+    assert result["profile"] == "default"
+    assert result["total"] == 42
+    assert result["orphan_count"] == 3
+    assert result["decay_eligible"] == 7
+    assert result["tag_distribution"][0]["share"] == 10 / 42
+
+
+def test_enrich_stats_adds_warmup_fields():
+    """enrich_stats should enrich stats without changing the base payload."""
+    from ogham.tools.stats import enrich_stats
+
+    with (
+        patch("ogham.tools.stats.get_all_memories_full") as mock_memories,
+        patch("ogham.tools.stats.get_related_memories") as mock_related,
+        patch("ogham.tools.stats.count_decay_eligible") as mock_decay,
+    ):
+        base_stats = {
+            "profile": "default",
+            "total": 20,
+            "sources": {"claude-code": 12},
+            "top_tags": [
+                {"tag": "project:foo", "count": 10},
+                {"tag": "type:decision", "count": 5},
+            ],
+        }
+        mock_memories.return_value = [
+            {"id": "memory-1"},
+            {"id": "memory-2"},
+            {"id": "memory-3"},
+        ]
+        mock_related.side_effect = [[], [{"id": "linked"}], []]
+        mock_decay.return_value = 7
+
+        result = enrich_stats("default", base_stats)
+
+    assert result["profile"] == "default"
+    assert result["orphan_count"] == 2
+    assert result["decay_eligible"] == 7
+    assert result["sources"] == {"claude-code": 12}
+    assert result["tag_distribution"] == [
+        {"tag": "project:foo", "count": 10, "share": 0.5},
+        {"tag": "type:decision", "count": 5, "share": 0.25},
+    ]
+
+
 # --- Expiration database tests ---
 
 


### PR DESCRIPTION
## Summary

Enriches the stats surface with a few profile health signals while keeping the existing base stats contract intact.

## What changed

- keeps `get_memory_stats()` as the base payload
- enriches `get_stats()` with `orphan_count`, `tag_distribution`, and `decay_eligible`
- updates `ogham stats` to display the same enriched signals
- adds focused tests for the new stats behaviour

## Why this shape

`enrich_stats()` is the smallest way to expand the stats surface without changing the base contract.

It keeps `get_memory_stats()` as the existing source of truth and layers the new health signals on top where they are actually needed: `get_stats()` and `ogham stats`. That keeps the change additive, avoids backend or schema changes, and prevents duplicating the same enrichment logic in multiple places.

## Trade-offs

- `orphan_count` is computed from existing Python/database calls, so it is simple and low-risk but may be slower on large profiles
- `tag_distribution` is derived from existing `top_tags`, so it improves readability without introducing a new storage or query contract
- `enrich_stats()` is intentionally a small shared helper; inlining it would reduce indirection, but would duplicate the same warm-up logic in both the MCP tool and CLI

## Future considerations

If these signals become core product stats rather than presentation-layer enrichments, we can revisit whether they belong in a stable backend contract or a more efficient query path. For now, keeping them as additive enrichment keeps the blast radius small and the change easy to revise.

## Validation

- `uv run ruff check src/ogham/tools/stats.py src/ogham/cli.py tests/test_cli.py tests/test_tools.py`
- `uv run pytest tests/test_cli.py -q`
- `uv run pytest tests/test_tools.py -q -k "get_stats_tool or enrich_stats"`
