### PR TITLE
feat: capture embedding token usage and audit cost

### DIFF
--- a/src/ogham/backends/postgres.py
+++ b/src/ogham/backends/postgres.py
@@ -379,6 +379,9 @@ class PostgresBackend:
         resource_id: str | None = None,
         outcome: str = "success",
         source: str | None = None,
+        embedding_model: str | None = None,
+        tokens_used: int | None = None,
+        cost_usd: float | None = None,
         result_ids: list[str] | None = None,
         result_count: int | None = None,
         query_hash: str | None = None,
@@ -389,16 +392,20 @@ class PostgresBackend:
             self._execute(
                 """INSERT INTO audit_log
                    (profile, operation, resource_id, outcome, source,
+                    embedding_model, tokens_used, cost_usd,
                     result_ids, result_count, query_hash, metadata)
                    VALUES (%(profile)s, %(operation)s, %(resource_id)s, %(outcome)s,
-                           %(source)s, %(result_ids)s, %(result_count)s,
-                           %(query_hash)s, %(metadata)s)""",
+                           %(source)s, %(embedding_model)s, %(tokens_used)s, %(cost_usd)s,
+                           %(result_ids)s, %(result_count)s, %(query_hash)s, %(metadata)s)""",
                 {
                     "profile": profile,
                     "operation": operation,
                     "resource_id": resource_id,
                     "outcome": outcome,
                     "source": source,
+                    "embedding_model": embedding_model,
+                    "tokens_used": tokens_used,
+                    "cost_usd": cost_usd,
                     "result_ids": result_ids,
                     "result_count": result_count,
                     "query_hash": query_hash,

--- a/src/ogham/embeddings.py
+++ b/src/ogham/embeddings.py
@@ -1,5 +1,16 @@
+"""Embedding generation plus optional usage sidecar capture.
+
+Callers that only need vectors use `generate_embedding()` /
+`generate_embeddings_batch()` exactly as before.
+
+Callers that also want provider usage pass a mutable `usage_out` dict.
+When provided, the function mutates it in place with best-effort fields
+such as `model`, `input_tokens`, and `cache_hit`.
+"""
+
 import hashlib
 import logging
+from typing import TypedDict
 
 from ogham.config import settings
 from ogham.embedding_cache import EmbeddingCache
@@ -13,68 +24,164 @@ _cache = EmbeddingCache(
 )
 
 
+class EmbeddingUsage(TypedDict, total=False):
+    """Best-effort provider usage captured alongside an embedding request."""
+
+    model: str
+    input_tokens: int
+    cache_hit: bool
+
+
 def get_cache_stats() -> dict:
     """Return cache statistics."""
     return _cache.stats()
 
 
 def _cache_key(text: str) -> str:
-    """Build a cache key scoped to the current provider and dimension.
+    """Build a cache key scoped to the current provider, model, and dimension.
 
-    Switching providers or dimensions automatically invalidates cached vectors
-    because the key prefix changes.
+    Switching providers, models, or dimensions automatically invalidates cached
+    vectors because the key prefix changes.
     """
-    prefix = f"{settings.embedding_provider}:{settings.embedding_dim}:"
+    prefix = f"{_current_embedding_model()}:{settings.embedding_dim}:"
     return hashlib.sha256((prefix + text).encode()).hexdigest()
 
 
-def generate_embedding(text: str) -> list[float]:
-    """Generate an embedding vector for the given text.
+def _current_embedding_model(provider: str | None = None) -> str:
+    """Return the normalized provider:model identifier used in audit rows."""
+    provider = provider or settings.embedding_provider
+    match provider:
+        case "ollama":
+            model = settings.ollama_embed_model
+        case "openai":
+            model = "text-embedding-3-small"
+        case "mistral":
+            model = settings.mistral_embed_model
+        case "voyage":
+            model = settings.voyage_embed_model
+        case "gemini":
+            model = settings.gemini_embed_model
+        case "onnx":
+            model = "local"
+        case _:
+            model = "unknown"
+    return f"{provider}:{model}"
 
-    Uses persistent SQLite cache keyed by provider + dimension + SHA256 of text
-    to avoid re-embedding identical content. Switching providers or dimensions
-    automatically invalidates cached vectors.
+
+def _cached_embedding_usage() -> EmbeddingUsage:
+    """Return the synthetic usage payload for a cache hit."""
+    return {
+        "model": _current_embedding_model(),
+        "input_tokens": 0,
+        "cache_hit": True,
+    }
+
+
+def _usage_dict(
+    *,
+    model: str,
+    input_tokens: int | None = None,
+    cache_hit: bool | None = None,
+) -> EmbeddingUsage:
+    """Build a compact usage payload, skipping unknown fields."""
+    usage: EmbeddingUsage = {"model": model}
+    if input_tokens is not None:
+        usage["input_tokens"] = int(input_tokens)
+    if cache_hit is not None:
+        usage["cache_hit"] = cache_hit
+    return usage
+
+
+def _set_usage_out(usage_out: EmbeddingUsage | None, usage: EmbeddingUsage | None) -> None:
+    """Replace the caller-provided usage sidecar in place when present."""
+    if usage_out is None or usage is None:
+        return
+    usage_out.clear()
+    usage_out.update(usage)
+
+
+def _merge_usage(
+    total: EmbeddingUsage | None,
+    current: EmbeddingUsage | None,
+) -> EmbeddingUsage | None:
+    """Accumulate usage across multiple provider calls in one logical request."""
+    if current is None:
+        return total
+    if total is None:
+        return dict(current)
+
+    merged: EmbeddingUsage = dict(total)
+    if not merged.get("model"):
+        merged["model"] = current.get("model", "")
+    if "input_tokens" in current:
+        merged["input_tokens"] = merged.get("input_tokens", 0) + current["input_tokens"]
+    merged["cache_hit"] = merged.get("cache_hit", False) and current.get("cache_hit", False)
+    return merged
+
+
+def _model_only_usage(provider: str) -> EmbeddingUsage:
+    """Return model provenance for providers that do not expose token usage."""
+    return _usage_dict(model=_current_embedding_model(provider))
+
+
+def generate_embedding(
+    text: str,
+    usage_out: EmbeddingUsage | None = None,
+) -> list[float]:
+    """Generate one embedding vector, optionally populating `usage_out`.
+
+    Uses persistent SQLite cache keyed by provider + model + dimension +
+    SHA256 of text to avoid re-embedding identical content. Switching
+    providers, models, or dimensions automatically invalidates cached vectors.
+
+    If `usage_out` is provided, it is mutated in place with best-effort usage
+    metadata for this request. Cache hits report `input_tokens=0`.
     """
     cache_key = _cache_key(text)
 
     cached = _cache.get(cache_key)
     if cached is not None:
         logger.debug("Embedding cache hit for text hash %s", cache_key[:8])
+        _set_usage_out(usage_out, _cached_embedding_usage())
         return cached
 
-    embedding = _generate_uncached(text)
+    embedding = _generate_uncached(text, usage_out=usage_out)
     _cache.put(cache_key, embedding)
     return embedding
 
 
 @with_retry(max_attempts=3, base_delay=0.5, exceptions=(ConnectionError, OSError))
-def _generate_uncached(text: str) -> list[float]:
-    """Generate embedding without cache lookup."""
+def _generate_uncached(
+    text: str,
+    usage_out: EmbeddingUsage | None = None,
+) -> list[float]:
+    """Generate one embedding without cache lookup, forwarding `usage_out`."""
     provider = settings.embedding_provider
 
     match provider:
         case "ollama":
-            return _embed_ollama(text)
+            return _embed_ollama(text, usage_out=usage_out)
         case "openai":
-            return _embed_openai(text)
+            return _embed_openai(text, usage_out=usage_out)
         case "mistral":
-            return _embed_mistral(text)
+            return _embed_mistral(text, usage_out=usage_out)
         case "voyage":
-            return _embed_voyage(text)
+            return _embed_voyage(text, usage_out=usage_out)
         case "gemini":
-            return _embed_gemini(text)
+            return _embed_gemini(text, usage_out=usage_out)
         case "onnx":
-            return _embed_onnx(text)
+            return _embed_onnx(text, usage_out=usage_out)
         case _:
             raise ValueError(f"Unknown embedding provider: {provider}")
 
 
-def _embed_onnx(text: str) -> list[float]:
+def _embed_onnx(text: str, usage_out: EmbeddingUsage | None = None) -> list[float]:
     from ogham.onnx_embedder import encode
 
     result = encode(text, settings.onnx_model_path or None)
     embedding = result.dense
     _validate_dim(embedding)
+    _set_usage_out(usage_out, _model_only_usage("onnx"))
     return embedding
 
 
@@ -90,7 +197,7 @@ def _get_ollama_client():
     return _ollama_client
 
 
-def _embed_ollama(text: str) -> list[float]:
+def _embed_ollama(text: str, usage_out: EmbeddingUsage | None = None) -> list[float]:
     client = _get_ollama_client()
     kwargs: dict = {"model": settings.ollama_embed_model, "input": text}
     if settings.embedding_dim:
@@ -98,6 +205,7 @@ def _embed_ollama(text: str) -> list[float]:
     response = client.embed(**kwargs)
     embedding = response["embeddings"][0]
     _validate_dim(embedding)
+    _set_usage_out(usage_out, _model_only_usage("ollama"))
     return embedding
 
 
@@ -113,7 +221,16 @@ def _get_openai_client():
     return _openai_client
 
 
-def _embed_openai(text: str) -> list[float]:
+def _extract_openai_usage(response) -> EmbeddingUsage:
+    """Extract best-effort token usage from an OpenAI embeddings response."""
+    usage = getattr(response, "usage", None)
+    input_tokens = getattr(usage, "total_tokens", None)
+    if input_tokens is None:
+        input_tokens = getattr(usage, "prompt_tokens", None)
+    return _usage_dict(model=_current_embedding_model("openai"), input_tokens=input_tokens)
+
+
+def _embed_openai(text: str, usage_out: EmbeddingUsage | None = None) -> list[float]:
     if not settings.openai_api_key:
         raise ValueError("OPENAI_API_KEY required when embedding_provider=openai")
 
@@ -125,6 +242,7 @@ def _embed_openai(text: str) -> list[float]:
     )
     embedding = response.data[0].embedding
     _validate_dim(embedding)
+    _set_usage_out(usage_out, _extract_openai_usage(response))
     return embedding
 
 
@@ -140,7 +258,7 @@ def _get_mistral_client():
     return _mistral_client
 
 
-def _embed_mistral(text: str) -> list[float]:
+def _embed_mistral(text: str, usage_out: EmbeddingUsage | None = None) -> list[float]:
     if not settings.mistral_api_key:
         raise ValueError("MISTRAL_API_KEY required when embedding_provider=mistral")
     client = _get_mistral_client()
@@ -150,6 +268,7 @@ def _embed_mistral(text: str) -> list[float]:
     )
     embedding = response.data[0].embedding
     _validate_dim(embedding)
+    _set_usage_out(usage_out, _model_only_usage("mistral"))
     return embedding
 
 
@@ -165,7 +284,15 @@ def _get_voyage_client():
     return _voyage_client
 
 
-def _embed_voyage(text: str) -> list[float]:
+def _extract_voyage_usage(response) -> EmbeddingUsage:
+    """Extract best-effort token usage from a Voyage embeddings response."""
+    return _usage_dict(
+        model=_current_embedding_model("voyage"),
+        input_tokens=getattr(response, "total_tokens", None),
+    )
+
+
+def _embed_voyage(text: str, usage_out: EmbeddingUsage | None = None) -> list[float]:
     if not settings.voyage_api_key:
         raise ValueError("VOYAGE_API_KEY required when embedding_provider=voyage")
     client = _get_voyage_client()
@@ -176,6 +303,7 @@ def _embed_voyage(text: str) -> list[float]:
     )
     embedding = response.embeddings[0]
     _validate_dim(embedding)
+    _set_usage_out(usage_out, _extract_voyage_usage(response))
     return embedding
 
 
@@ -194,7 +322,16 @@ def _get_gemini_client():
 _EMBED_MAX_CHARS = 20000  # ~6-7K tokens at typical 3-4 chars/token, safe for 8191 token limit
 
 
-def _embed_gemini(text: str) -> list[float]:
+def _extract_gemini_usage(response) -> EmbeddingUsage:
+    """Extract best-effort token usage from a Gemini embeddings response."""
+    metadata = getattr(response, "usage_metadata", None) or getattr(response, "usageMetadata", None)
+    prompt_tokens = getattr(metadata, "prompt_token_count", None)
+    if prompt_tokens is None and isinstance(metadata, dict):
+        prompt_tokens = metadata.get("prompt_token_count")
+    return _usage_dict(model=_current_embedding_model("gemini"), input_tokens=prompt_tokens)
+
+
+def _embed_gemini(text: str, usage_out: EmbeddingUsage | None = None) -> list[float]:
     if not settings.gemini_api_key:
         raise ValueError("GEMINI_API_KEY required when embedding_provider=gemini")
     client = _get_gemini_client()
@@ -205,6 +342,7 @@ def _embed_gemini(text: str) -> list[float]:
     )
     embedding = response.embeddings[0].values
     _validate_dim(embedding)
+    _set_usage_out(usage_out, _extract_gemini_usage(response))
     return embedding
 
 
@@ -219,20 +357,25 @@ def generate_embeddings_batch(
     texts: list[str],
     batch_size: int | None = None,
     on_progress: callable = None,
+    usage_out: EmbeddingUsage | None = None,
 ) -> list[list[float]]:
     """Generate embeddings for multiple texts, batched for efficiency.
+    Optionally populating `usage_out`.
 
     Checks cache first, batches uncached texts through the provider,
     and returns results in original order.
 
     Args:
         on_progress: Optional callback(embedded_so_far, total) called after each batch.
+        usage_out: Optional dict mutated in place with aggregated usage for
+            uncached provider calls only. Cache-hit items contribute zero spend.
     """
     if batch_size is None:
         batch_size = settings.embedding_batch_size
     total = len(texts)
     results: list[list[float] | None] = [None] * total
     uncached: list[tuple[int, str, str]] = []  # (index, cache_key, text)
+    total_usage: EmbeddingUsage | None = None
 
     for i, text in enumerate(texts):
         cache_key = _cache_key(text)
@@ -251,44 +394,58 @@ def generate_embeddings_batch(
     for start in range(0, len(uncached), batch_size):
         batch = uncached[start : start + batch_size]
         batch_texts = [t for _, _, t in batch]
-        embeddings = _generate_batch_uncached(batch_texts)
+        batch_usage: EmbeddingUsage = {}
+        embeddings = _generate_batch_uncached(batch_texts, usage_out=batch_usage)
         for (idx, cache_key, _), embedding in zip(batch, embeddings):
             results[idx] = embedding
             _cache.put(cache_key, embedding)
+        total_usage = _merge_usage(total_usage, batch_usage or None)
         embedded += len(batch)
         if on_progress:
             on_progress(embedded, total)
 
+    _set_usage_out(usage_out, total_usage)
     return results
 
 
 @with_retry(max_attempts=3, base_delay=0.5, exceptions=(ConnectionError, OSError))
-def _generate_batch_uncached(texts: list[str]) -> list[list[float]]:
-    """Generate embeddings for a batch of texts without cache lookup."""
+def _generate_batch_uncached(
+    texts: list[str],
+    usage_out: EmbeddingUsage | None = None,
+) -> list[list[float]]:
+    """Generate embeddings for a batch of texts without cache lookup. Forwarding `usage_out`."""
     provider = settings.embedding_provider
 
     match provider:
         case "ollama":
-            return _embed_ollama_batch(texts)
+            return _embed_ollama_batch(texts, usage_out=usage_out)
         case "openai":
-            return _embed_openai_batch(texts)
+            return _embed_openai_batch(texts, usage_out=usage_out)
         case "mistral":
-            return _embed_mistral_batch(texts)
+            return _embed_mistral_batch(texts, usage_out=usage_out)
         case "voyage":
-            return _embed_voyage_batch(texts)
+            return _embed_voyage_batch(texts, usage_out=usage_out)
         case "gemini":
-            return _embed_gemini_batch(texts)
+            return _embed_gemini_batch(texts, usage_out=usage_out)
         case "onnx":
-            return _embed_onnx_batch(texts)
+            return _embed_onnx_batch(texts, usage_out=usage_out)
         case _:
             raise ValueError(f"Unknown embedding provider: {provider}")
 
 
-def _embed_onnx_batch(texts: list[str]) -> list[list[float]]:
-    return [_embed_onnx(t) for t in texts]
+def _embed_onnx_batch(
+    texts: list[str],
+    usage_out: EmbeddingUsage | None = None,
+) -> list[list[float]]:
+    embeddings = [_embed_onnx(t) for t in texts]
+    _set_usage_out(usage_out, _model_only_usage("onnx"))
+    return embeddings
 
 
-def _embed_ollama_batch(texts: list[str]) -> list[list[float]]:
+def _embed_ollama_batch(
+    texts: list[str],
+    usage_out: EmbeddingUsage | None = None,
+) -> list[list[float]]:
     client = _get_ollama_client()
     kwargs: dict = {"model": settings.ollama_embed_model, "input": texts}
     if settings.embedding_dim:
@@ -297,10 +454,14 @@ def _embed_ollama_batch(texts: list[str]) -> list[list[float]]:
     embeddings = response["embeddings"]
     for emb in embeddings:
         _validate_dim(emb)
+    _set_usage_out(usage_out, _model_only_usage("ollama"))
     return embeddings
 
 
-def _embed_openai_batch(texts: list[str]) -> list[list[float]]:
+def _embed_openai_batch(
+    texts: list[str],
+    usage_out: EmbeddingUsage | None = None,
+) -> list[list[float]]:
     if not settings.openai_api_key:
         raise ValueError("OPENAI_API_KEY required when embedding_provider=openai")
 
@@ -313,10 +474,14 @@ def _embed_openai_batch(texts: list[str]) -> list[list[float]]:
     embeddings = [d.embedding for d in response.data]
     for emb in embeddings:
         _validate_dim(emb)
+    _set_usage_out(usage_out, _extract_openai_usage(response))
     return embeddings
 
 
-def _embed_mistral_batch(texts: list[str]) -> list[list[float]]:
+def _embed_mistral_batch(
+    texts: list[str],
+    usage_out: EmbeddingUsage | None = None,
+) -> list[list[float]]:
     if not settings.mistral_api_key:
         raise ValueError("MISTRAL_API_KEY required when embedding_provider=mistral")
     client = _get_mistral_client()
@@ -327,14 +492,19 @@ def _embed_mistral_batch(texts: list[str]) -> list[list[float]]:
     embeddings = [d.embedding for d in response.data]
     for emb in embeddings:
         _validate_dim(emb)
+    _set_usage_out(usage_out, _model_only_usage("mistral"))
     return embeddings
 
 
-def _embed_voyage_batch(texts: list[str]) -> list[list[float]]:
+def _embed_voyage_batch(
+    texts: list[str],
+    usage_out: EmbeddingUsage | None = None,
+) -> list[list[float]]:
     if not settings.voyage_api_key:
         raise ValueError("VOYAGE_API_KEY required when embedding_provider=voyage")
     client = _get_voyage_client()
     all_embeddings = []
+    total_usage: EmbeddingUsage | None = None
     # Voyage max 1000 per request
     for start in range(0, len(texts), 1000):
         batch = texts[start : start + 1000]
@@ -344,8 +514,10 @@ def _embed_voyage_batch(texts: list[str]) -> list[list[float]]:
             output_dimension=settings.embedding_dim,
         )
         all_embeddings.extend(response.embeddings)
+        total_usage = _merge_usage(total_usage, _extract_voyage_usage(response))
     for emb in all_embeddings:
         _validate_dim(emb)
+    _set_usage_out(usage_out, total_usage)
     return all_embeddings
 
 
@@ -361,7 +533,10 @@ def _is_rate_limit_error(exc: BaseException) -> bool:
     )
 
 
-def _embed_gemini_batch(texts: list[str]) -> list[list[float]]:
+def _embed_gemini_batch(
+    texts: list[str],
+    usage_out: EmbeddingUsage | None = None,
+) -> list[list[float]]:
     if not settings.gemini_api_key:
         raise ValueError("GEMINI_API_KEY required when embedding_provider=gemini")
     client = _get_gemini_client()
@@ -390,6 +565,7 @@ def _embed_gemini_batch(texts: list[str]) -> list[list[float]]:
         embeddings = [e.values for e in response.embeddings]
         for emb in embeddings:
             _validate_dim(emb)
+        _set_usage_out(usage_out, _extract_gemini_usage(response))
         return embeddings
 
     return _call()

--- a/src/ogham/pricing.py
+++ b/src/ogham/pricing.py
@@ -1,0 +1,44 @@
+"""Embedding pricing helpers used by audit logging."""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Rates in USD per 1K input tokens for repo-enabled remote embedding models.
+# Verified against official pricing pages on 2026-04-14. Re-check upstream
+# pricing pages when repo defaults change or provider pricing is updated:
+# The contributor brief showed a broader sample table; this module keeps the
+# initial scope narrower to repo-enabled models and conservative Gemini handling.
+# - OpenAI: https://platform.openai.com/docs/pricing/
+# - Voyage: https://docs.voyageai.com/docs/pricing
+# - Google Vertex AI: https://cloud.google.com/vertex-ai/generative-ai/pricing?hl=en
+EMBEDDING_PRICING_PER_1K_TOKENS: dict[str, float] = {
+    "openai:text-embedding-3-small": 0.00002,
+    "voyage:voyage-4-lite": 0.00002,
+}
+
+
+def calculate_embedding_cost(usage: dict[str, Any] | None) -> float | None:
+    """Return estimated USD cost for an embedding request."""
+    if not usage:
+        return None
+
+    model = usage.get("model")
+    if not model:
+        return None
+
+    if model.startswith("ollama:") or model.startswith("onnx:"):
+        return 0.0
+
+    if model.startswith("gemini:"):
+        return None
+
+    input_tokens = usage.get("input_tokens")
+    if input_tokens is None:
+        return None
+
+    rate = EMBEDDING_PRICING_PER_1K_TOKENS.get(model)
+    if rate is None:
+        return None
+
+    return round((float(input_tokens) / 1000.0) * rate, 8)

--- a/src/ogham/service.py
+++ b/src/ogham/service.py
@@ -10,6 +10,7 @@ import hashlib
 import logging
 import os
 import re
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -23,7 +24,7 @@ from ogham.database import (
 )
 from ogham.database import get_profile_ttl as db_get_profile_ttl
 from ogham.database import store_memory as db_store
-from ogham.embeddings import generate_embedding
+from ogham.embeddings import EmbeddingUsage, generate_embedding
 from ogham.extraction import (
     compute_importance,
     extract_dates,
@@ -37,8 +38,36 @@ from ogham.extraction import (
     is_ordering_query,
     resolve_temporal_query,
 )
+from ogham.pricing import calculate_embedding_cost
 
 logger = logging.getLogger(__name__)
+
+
+def _merge_embedding_usage(
+    total: EmbeddingUsage | None, current: EmbeddingUsage | None
+) -> EmbeddingUsage | None:
+    if current is None:
+        return total
+    if total is None:
+        return dict(current)
+
+    merged: EmbeddingUsage = dict(total)
+    current_tokens = current.get("input_tokens")
+    if current_tokens is not None:
+        merged["input_tokens"] = merged.get("input_tokens", 0) + current_tokens
+    if not merged.get("model"):
+        merged["model"] = current.get("model", "")
+    return merged
+
+
+def _audit_usage_fields(usage: EmbeddingUsage | None) -> dict[str, Any]:
+    if usage is None:
+        return {}
+    return {
+        "embedding_model": usage.get("model"),
+        "tokens_used": usage.get("input_tokens"),
+        "cost_usd": calculate_embedding_cost(usage),
+    }
 
 
 def store_memory_enriched(
@@ -91,8 +120,10 @@ def store_memory_enriched(
     metadata["original_importance"] = importance
 
     # Generate embedding (skip if pre-computed, e.g. from gateway cache)
+    embedding_usage = None
     if embedding is None:
-        embedding = generate_embedding(content)
+        embedding_usage = {}
+        embedding = generate_embedding(content, usage_out=embedding_usage)
 
     # Compute surprise score + detect conflicts (>75% similarity)
     surprise = 0.5
@@ -174,6 +205,7 @@ def store_memory_enriched(
         resource_id=str(result["id"]),
         source=source,
         metadata={"importance": importance, "surprise": surprise},
+        **_audit_usage_fields(embedding_usage),
     )
 
     return response
@@ -289,6 +321,21 @@ def search_memories_enriched(
             extract query-relevant facts. Returns a single extracted-facts
             result instead of raw memories. Default: False (verbatim results).
     """
+    embedding_usage: EmbeddingUsage | None = None
+
+    if embedding is None:
+        def _generate_embedding_with_usage_tracking(text: str) -> list[float]:
+            nonlocal embedding_usage
+            current_usage: EmbeddingUsage = {}
+            result = generate_embedding(text, usage_out=current_usage)
+            embedding_usage = _merge_embedding_usage(embedding_usage, current_usage or None)
+            return result
+
+        embedding = _generate_embedding_with_usage_tracking(query)
+        embedding_generator = _generate_embedding_with_usage_tracking
+    else:
+        embedding_generator = generate_embedding
+
     results = _search_memories_raw(
         query,
         profile,
@@ -298,6 +345,7 @@ def search_memories_enriched(
         graph_depth,
         embedding,
         profiles,
+        embedding_generator=embedding_generator,
     )
 
     if results:
@@ -313,6 +361,7 @@ def search_memories_enriched(
         result_ids=result_ids or None,
         result_count=len(results),
         query_hash=hashlib.sha256(query.encode()).hexdigest()[:16],
+        **_audit_usage_fields(embedding_usage),
     )
 
     if extract_facts and results:
@@ -485,10 +534,11 @@ def _search_memories_raw(
     graph_depth: int = 0,
     embedding: list[float] | None = None,
     profiles: list[str] | None = None,
+    embedding_generator: Callable[[str], list[float]] = generate_embedding,
 ) -> list[dict[str, Any]]:
     """Retrieve memories via intent-aware search paths. No reranking, no access recording."""
     if embedding is None:
-        embedding = generate_embedding(query)
+        embedding = embedding_generator(query)
 
     # Query reformulation disabled — global application regressed MRR (2026-04-10).
     search_query = query
@@ -533,7 +583,14 @@ def _search_memories_raw(
 
     # Multi-hop temporal: entity-centric bridge retrieval + threading
     if is_multi_hop_temporal(query):
-        bridge_results = _bridge_retrieval(query, profile, elastic_limit, tags, source)
+        bridge_results = _bridge_retrieval(
+            query,
+            profile,
+            elastic_limit,
+            tags,
+            source,
+            embedding_generator,
+        )
         if bridge_results:
             results = _merge_bridge_results(
                 bridge_results,
@@ -652,6 +709,7 @@ def _bridge_retrieval(
     limit: int,
     tags: list[str] | None,
     source: str | None,
+    embedding_generator: Callable[[str], list[float]] = generate_embedding,
 ) -> list[dict[str, Any]]:
     """Entity-centric bridge retrieval for multi-hop temporal queries.
 
@@ -668,7 +726,7 @@ def _bridge_retrieval(
     all_results = []
     for anchor in anchors:
         # Path A: Semantic + keyword hybrid search
-        anchor_embedding = generate_embedding(anchor)
+        anchor_embedding = embedding_generator(anchor)
         results = hybrid_search_memories(
             query_text=anchor,
             query_embedding=anchor_embedding,

--- a/tests/test_audit_embedding_usage.py
+++ b/tests/test_audit_embedding_usage.py
@@ -1,0 +1,288 @@
+from unittest.mock import patch
+
+import pytest
+
+FAKE_EMBEDDING = [0.1] * 1024
+
+
+@pytest.fixture(autouse=True)
+def mock_settings(monkeypatch):
+    monkeypatch.setenv("SUPABASE_URL", "https://fake.supabase.co")
+    monkeypatch.setenv("SUPABASE_KEY", "fake-key")
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "openai")
+    monkeypatch.setenv("DEFAULT_PROFILE", "default")
+
+    from ogham.config import settings
+
+    settings._reset()
+    yield
+    settings._reset()
+
+
+@pytest.fixture
+def isolated_cache(tmp_path):
+    import ogham.embeddings as emb
+    from ogham.embedding_cache import EmbeddingCache
+
+    old_cache = emb._cache
+    emb._cache = EmbeddingCache(cache_dir=str(tmp_path), max_size=20)
+    try:
+        yield emb
+    finally:
+        emb._cache = old_cache
+
+
+def test_cache_key_includes_model(monkeypatch):
+    from ogham.config import settings
+    from ogham.embeddings import _cache_key
+
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "voyage")
+    monkeypatch.setenv("VOYAGE_EMBED_MODEL", "voyage-4-lite")
+    settings._reset()
+    key_one = _cache_key("same text")
+
+    monkeypatch.setenv("VOYAGE_EMBED_MODEL", "voyage-4")
+    settings._reset()
+    key_two = _cache_key("same text")
+
+    assert key_one != key_two
+
+
+def test_generate_embedding_usage_out_cache_hit_returns_zero_tokens(isolated_cache):
+    from ogham.embeddings import generate_embedding
+
+    def fake_generate(text, usage_out=None):
+        if usage_out is not None:
+            usage_out.update({"model": "openai:text-embedding-3-small", "input_tokens": 25})
+        return FAKE_EMBEDDING
+
+    with patch("ogham.embeddings._generate_uncached", side_effect=fake_generate) as mock_gen:
+        first_usage = {}
+        second_usage = {}
+        generate_embedding("cached text", usage_out=first_usage)
+        generate_embedding("cached text", usage_out=second_usage)
+
+    assert mock_gen.call_count == 1
+    assert first_usage == {"model": "openai:text-embedding-3-small", "input_tokens": 25}
+    assert second_usage == {
+        "model": "openai:text-embedding-3-small",
+        "input_tokens": 0,
+        "cache_hit": True,
+    }
+
+
+def test_generate_embeddings_batch_usage_out_counts_uncached_only(isolated_cache):
+    from ogham.embeddings import _cache_key, generate_embeddings_batch
+
+    isolated_cache._cache.put(_cache_key("cached"), FAKE_EMBEDDING)
+
+    def fake_batch_generate(texts, usage_out=None):
+        if usage_out is not None:
+            usage_out.update({"model": "openai:text-embedding-3-small", "input_tokens": 40})
+        return [[0.2] * 1024 for _ in texts]
+
+    with patch(
+        "ogham.embeddings._generate_batch_uncached",
+        side_effect=fake_batch_generate,
+    ) as mock_batch:
+        usage = {}
+        embeddings = generate_embeddings_batch(
+            ["cached", "new one", "new two"],
+            usage_out=usage,
+        )
+
+    assert len(embeddings) == 3
+    assert embeddings[0] == FAKE_EMBEDDING
+    assert mock_batch.call_count == 1
+    assert mock_batch.call_args.args[0] == ["new one", "new two"]
+    assert usage == {"model": "openai:text-embedding-3-small", "input_tokens": 40}
+
+
+def test_calculate_embedding_cost_uses_repo_model_rate():
+    from ogham.pricing import calculate_embedding_cost
+
+    cost = calculate_embedding_cost(
+        {"model": "openai:text-embedding-3-small", "input_tokens": 250}
+    )
+
+    assert cost == pytest.approx(0.000005)
+
+
+def test_calculate_embedding_cost_returns_none_for_unknown_and_gemini_models():
+    from ogham.pricing import calculate_embedding_cost
+
+    assert calculate_embedding_cost({"model": "voyage:voyage-unknown", "input_tokens": 100}) is None
+    assert (
+        calculate_embedding_cost(
+            {"model": "gemini:gemini-embedding-2-preview", "input_tokens": 100}
+        )
+        is None
+    )
+    assert calculate_embedding_cost({"model": "ollama:embeddinggemma"}) == 0.0
+
+
+def test_store_memory_audit_includes_embedding_usage():
+    from ogham.service import store_memory_enriched
+
+    with (
+        patch(
+            "ogham.service.generate_embedding",
+            side_effect=lambda text, usage_out=None: (
+                usage_out.update({"model": "openai:text-embedding-3-small", "input_tokens": 250})
+                if usage_out is not None
+                else None
+            )
+            or FAKE_EMBEDDING,
+        ),
+        patch("ogham.service.hybrid_search_memories", return_value=[]),
+        patch("ogham.service.db_get_profile_ttl", return_value=None),
+        patch(
+            "ogham.service.db_store",
+            return_value={"id": "mem-123", "created_at": "2026-01-01T00:00:00Z"},
+        ),
+        patch("ogham.service.db_auto_link", return_value=0),
+        patch("ogham.service.emit_audit_event") as audit,
+        patch("ogham.service.extract_dates", return_value=[]),
+        patch("ogham.service.extract_entities", return_value=[]),
+        patch("ogham.service.extract_recurrence", return_value=[]),
+        patch("ogham.service.compute_importance", return_value=0.7),
+        patch("ogham.hooks._mask_secrets", side_effect=lambda text: text),
+    ):
+        result = store_memory_enriched(
+            content="This memory is long enough to pass validation.",
+            profile="default",
+            source="test",
+        )
+
+    assert result["status"] == "stored"
+    audit.assert_called_once()
+    assert audit.call_args.kwargs["embedding_model"] == "openai:text-embedding-3-small"
+    assert audit.call_args.kwargs["tokens_used"] == 250
+    assert audit.call_args.kwargs["cost_usd"] == pytest.approx(0.000005)
+
+
+def test_store_memory_precomputed_embedding_leaves_usage_null():
+    from ogham.service import store_memory_enriched
+
+    with (
+        patch("ogham.service.generate_embedding") as generate,
+        patch("ogham.service.hybrid_search_memories", return_value=[]),
+        patch("ogham.service.db_get_profile_ttl", return_value=None),
+        patch(
+            "ogham.service.db_store",
+            return_value={"id": "mem-123", "created_at": "2026-01-01T00:00:00Z"},
+        ),
+        patch("ogham.service.db_auto_link", return_value=0),
+        patch("ogham.service.emit_audit_event") as audit,
+        patch("ogham.service.extract_dates", return_value=[]),
+        patch("ogham.service.extract_entities", return_value=[]),
+        patch("ogham.service.extract_recurrence", return_value=[]),
+        patch("ogham.service.compute_importance", return_value=0.7),
+        patch("ogham.hooks._mask_secrets", side_effect=lambda text: text),
+    ):
+        store_memory_enriched(
+            content="This memory is long enough to pass validation.",
+            profile="default",
+            source="test",
+            embedding=FAKE_EMBEDDING,
+        )
+
+    generate.assert_not_called()
+    assert "embedding_model" not in audit.call_args.kwargs
+    assert "tokens_used" not in audit.call_args.kwargs
+    assert "cost_usd" not in audit.call_args.kwargs
+
+
+def test_search_audit_accumulates_full_embedding_usage():
+    from ogham.service import search_memories_enriched
+
+    usage_calls = [
+        (FAKE_EMBEDDING, {"model": "openai:text-embedding-3-small", "input_tokens": 10}),
+        (FAKE_EMBEDDING, {"model": "openai:text-embedding-3-small", "input_tokens": 20}),
+        (FAKE_EMBEDDING, {"model": "openai:text-embedding-3-small", "input_tokens": 30}),
+    ]
+    bridge_result = {"id": "mem-1", "content": "bridge result", "relevance": 0.9}
+
+    with (
+        patch(
+            "ogham.service.generate_embedding",
+            side_effect=lambda text, usage_out=None: (
+                usage_out.update(usage_calls.pop(0)[1]) if usage_out is not None else None
+            )
+            or FAKE_EMBEDDING,
+        ),
+        patch("ogham.service.is_ordering_query", return_value=False),
+        patch("ogham.service.is_multi_hop_temporal", return_value=True),
+        patch("ogham.service.is_cross_reference_query", return_value=False),
+        patch("ogham.service.is_broad_summary_query", return_value=False),
+        patch("ogham.service.has_temporal_intent", return_value=False),
+        patch("ogham.service.extract_entities", return_value=[]),
+        patch("ogham.service.extract_query_anchors", return_value=["alpha", "beta"]),
+        patch("ogham.service.hybrid_search_memories", return_value=[bridge_result]),
+        patch("ogham.service._merge_bridge_results", return_value=[bridge_result]),
+        patch("ogham.service._entity_thread", side_effect=lambda results, *_: results),
+        patch("ogham.service.record_access"),
+        patch("ogham.service.emit_audit_event") as audit,
+    ):
+        results = search_memories_enriched("When did alpha and beta happen?", profile="default")
+
+    assert results == [bridge_result]
+    audit.assert_called_once()
+    assert audit.call_args.kwargs["embedding_model"] == "openai:text-embedding-3-small"
+    assert audit.call_args.kwargs["tokens_used"] == 60
+    assert audit.call_args.kwargs["cost_usd"] == pytest.approx(0.0000012)
+
+
+def test_search_precomputed_embedding_leaves_usage_null_without_extra_embeds():
+    from ogham.service import search_memories_enriched
+
+    result = {"id": "mem-1", "content": "result", "relevance": 0.8}
+
+    with (
+        patch("ogham.service.generate_embedding") as generate,
+        patch("ogham.service.is_ordering_query", return_value=False),
+        patch("ogham.service.is_multi_hop_temporal", return_value=False),
+        patch("ogham.service.is_cross_reference_query", return_value=False),
+        patch("ogham.service.is_broad_summary_query", return_value=False),
+        patch("ogham.service.has_temporal_intent", return_value=False),
+        patch("ogham.service.extract_entities", return_value=[]),
+        patch("ogham.service.hybrid_search_memories", return_value=[result]),
+        patch("ogham.service.record_access"),
+        patch("ogham.service.emit_audit_event") as audit,
+    ):
+        results = search_memories_enriched(
+            "query",
+            profile="default",
+            embedding=FAKE_EMBEDDING,
+        )
+
+    assert results == [result]
+    generate.assert_not_called()
+    assert "embedding_model" not in audit.call_args.kwargs
+    assert "tokens_used" not in audit.call_args.kwargs
+    assert "cost_usd" not in audit.call_args.kwargs
+
+
+def test_postgres_audit_insert_includes_cost_columns():
+    from ogham.backends.postgres import PostgresBackend
+
+    backend = PostgresBackend()
+
+    with patch.object(backend, "_execute") as execute:
+        backend.emit_audit_event(
+            profile="default",
+            operation="search",
+            embedding_model="openai:text-embedding-3-small",
+            tokens_used=123,
+            cost_usd=0.00000246,
+        )
+
+    sql = execute.call_args.args[0]
+    params = execute.call_args.args[1]
+    assert "embedding_model" in sql
+    assert "tokens_used" in sql
+    assert "cost_usd" in sql
+    assert params["embedding_model"] == "openai:text-embedding-3-small"
+    assert params["tokens_used"] == 123
+    assert params["cost_usd"] == pytest.approx(0.00000246)
+    assert execute.call_args.kwargs["fetch"] == "none"


### PR DESCRIPTION
## Why
Part D needs `tokens_used` and `cost_usd` to land in `audit_log` so observability surfaces have real cost data.

This follows the explicit path discussed with the author: capture usage in the embedding layer, then pass it through the existing audit call sites in `store_memory_enriched()` and `search_memories_enriched()`.

## What changed
- capture best-effort embedding usage in `embeddings.py`
- add `pricing.py` for verified per-1k-token pricing
- write `embedding_model`, `tokens_used`, and `cost_usd` through `emit_audit_event()`
- add focused tests for cache behavior, audit wiring, pricing, and Postgres insert behavior

## Why this shape
- Extend existing embedding APIs with optional `usage_out` sidecars instead of adding parallel `_with_usage` APIs.
  Lower blast radius and no return-shape churn across callers.
- Keep provider parsing in `embeddings.py` and request-level rollup in `service.py`.
  Providers know how to extract usage; the service layer knows what counts as one request.
- Keep raw retrieval helpers returning results only.
  Usage accumulation is observability wiring, not their core contract.
- Make the embedding cache model-aware.
  Model switches within a provider should not misattribute cached usage.
- Keep pricing conservative.
  Verified repo-enabled remote models are priced; unclear Gemini pricing remains `NULL` instead of guessed.

## Trade-offs
- `service.py` is touched, but only additively in the existing audit wiring zone.
- Some usage rows may still have `cost_usd = NULL` until more model mappings are intentionally added.
- Cache keys invalidate on model change more often, which is the correct trade-off for accurate observability.

## Future considerations
- Extend pricing coverage if additional remote embedding models become repo defaults.
- If request-level usage rules grow more complex, move the search-side rollup into a small dedicated internal accumulator object.

## Validation
- `uv run ruff check src/ogham/embeddings.py src/ogham/service.py src/ogham/pricing.py src/ogham/backends/postgres.py tests/test_audit_embedding_usage.py`
- `uv run pytest tests/test_audit_embedding_usage.py`
