### PR TITLE
Coerce stringified list/dict tool parameters for FastMCP client compatibility

### DIFF
--- a/src/ogham/tools/memory.py
+++ b/src/ogham/tools/memory.py
@@ -1,11 +1,13 @@
 import functools
+import json
 import logging
 import re
 import time
 from datetime import datetime, timezone
-from typing import Any
+from typing import Annotated, Any
 
 from fastmcp import Context
+from pydantic import BeforeValidator
 
 from ogham.app import mcp
 from ogham.config import settings
@@ -33,6 +35,49 @@ from ogham.extraction import extract_dates
 from ogham.health import full_health_check
 
 logger = logging.getLogger(__name__)
+
+# === FastMCP list/dict coercion wrappers ===
+# Some FastMCP clients serialise list[str] and dict[str, Any] tool parameters
+# as JSON strings before the transport layer. Pydantic on the server then sees
+# a `str` and fails list_type / dict_type validation, surfacing as
+# JSON-RPC -32602 Invalid params. BeforeValidator-based coercion accepts
+# either the native shape or its JSON-string form and returns the canonical
+# Python shape. Same idiom as fastmcp/utilities/components.py:82.
+
+
+def _coerce_list(v):
+    if v is None or isinstance(v, list):
+        return v
+    if isinstance(v, str):
+        try:
+            parsed = json.loads(v)
+            if isinstance(parsed, list):
+                return parsed
+        except (json.JSONDecodeError, ValueError):
+            pass
+        # Fallback: a bare string that isn't JSON becomes a 1-element list.
+        # Pragmatic for tag-like fields where a single bare tag is common.
+        return [v]
+    raise TypeError(f"Cannot coerce {type(v).__name__} to list")
+
+
+def _coerce_dict(v):
+    if v is None or isinstance(v, dict):
+        return v
+    if isinstance(v, str):
+        try:
+            parsed = json.loads(v)
+            if isinstance(parsed, dict):
+                return parsed
+        except (json.JSONDecodeError, ValueError):
+            pass
+    raise TypeError(f"Cannot coerce {type(v).__name__} to dict")
+
+
+ListStr = Annotated[list[str] | None, BeforeValidator(_coerce_list)]
+DictAny = Annotated[dict[str, Any] | None, BeforeValidator(_coerce_dict)]
+
+
 
 MAX_CONTENT_LEN = 100_000
 MAX_LIMIT = 1_000
@@ -140,8 +185,8 @@ def list_profiles() -> list[dict[str, Any]]:
 def store_memory(
     content: str,
     source: str | None = None,
-    tags: list[str] | None = None,
-    metadata: dict[str, Any] | None = None,
+    tags: ListStr = None,
+    metadata: DictAny = None,
     auto_link: bool = True,
 ) -> dict[str, Any]:
     """Store a memory in the active profile with automatic embedding generation.
@@ -170,10 +215,10 @@ def store_memory(
 def store_decision(
     decision: str,
     rationale: str,
-    alternatives: list[str] | None = None,
+    alternatives: ListStr = None,
     reasoning_trace: str | None = None,
-    tags: list[str] | None = None,
-    related_memories: list[str] | None = None,
+    tags: ListStr = None,
+    related_memories: ListStr = None,
     source: str | None = None,
 ) -> dict[str, Any]:
     """Store an architectural decision with rationale. Creates a memory with
@@ -241,10 +286,10 @@ def store_decision(
 def hybrid_search(
     query: str,
     limit: int = 10,
-    tags: list[str] | None = None,
+    tags: ListStr = None,
     source: str | None = None,
     graph_depth: int = 0,
-    profiles: list[str] | None = None,
+    profiles: ListStr = None,
     extract_facts: bool = False,
 ) -> list[dict[str, Any]]:
     """Search memories in the active profile by meaning and keywords (hybrid search).
@@ -285,7 +330,7 @@ def hybrid_search(
 def list_recent(
     limit: int = 10,
     source: str | None = None,
-    tags: list[str] | None = None,
+    tags: ListStr = None,
 ) -> list[dict[str, Any]]:
     """List recent memories in the active profile.
 
@@ -323,8 +368,8 @@ def delete_memory(memory_id: str) -> dict[str, Any]:
 def update_memory(
     memory_id: str,
     content: str | None = None,
-    tags: list[str] | None = None,
-    metadata: dict[str, Any] | None = None,
+    tags: ListStr = None,
+    metadata: DictAny = None,
 ) -> dict[str, Any]:
     """Update an existing memory. Re-embeds if content changes.
 
@@ -574,7 +619,7 @@ def explore_knowledge(
     depth: int = 1,
     min_strength: float = 0.5,
     limit: int = 5,
-    tags: list[str] | None = None,
+    tags: ListStr = None,
     source: str | None = None,
 ) -> list[dict[str, Any]]:
     """Explore what you know about a topic. Finds relevant memories then
@@ -612,7 +657,7 @@ def explore_knowledge(
 @log_timing("find_related")
 def find_related(
     memory_id: str,
-    relationship_types: list[str] | None = None,
+    relationship_types: ListStr = None,
     depth: int = 1,
     min_strength: float = 0.5,
     limit: int = 20,

--- a/tests/test_list_coercion.py
+++ b/tests/test_list_coercion.py
@@ -1,0 +1,131 @@
+"""
+Tests for Conv 2.41 / KE-028 upstream fix: Annotated[T|None, BeforeValidator(coerce)]
+coercion wrappers on tool parameters in ogham/tools/memory.py.
+
+Drop this into the upstream tests/ directory (or ogham/tests/ — check upstream layout).
+Adjust imports once you've confirmed upstream's exact module path.
+
+Run: pytest tests/test_list_coercion.py -v
+"""
+
+import json
+import pytest
+from pydantic import ValidationError, TypeAdapter
+
+# Adjust this import after clone + reading upstream layout:
+from ogham.tools.memory import (
+    _coerce_list,
+    _coerce_dict,
+    ListStr,
+    DictAny,
+)
+
+
+class TestCoerceList:
+    def test_native_list_unchanged(self):
+        assert _coerce_list(["a", "b", "c"]) == ["a", "b", "c"]
+
+    def test_empty_list_unchanged(self):
+        assert _coerce_list([]) == []
+
+    def test_none_passes_through(self):
+        assert _coerce_list(None) is None
+
+    def test_json_string_list_coerced(self):
+        assert _coerce_list('["a","b","c"]') == ["a", "b", "c"]
+
+    def test_empty_json_array_coerced(self):
+        assert _coerce_list("[]") == []
+
+    def test_bare_string_wraps_as_single_element(self):
+        # Fallback: a bare string that isn't JSON becomes a 1-element list.
+        # This is the pragmatic behavior for tag-like fields.
+        assert _coerce_list("foo") == ["foo"]
+
+    def test_invalid_json_wraps_as_single_element(self):
+        # Not valid JSON → fallback to [v]
+        assert _coerce_list("not{valid]json") == ["not{valid]json"]
+
+    def test_json_string_that_parses_to_dict_rejected(self):
+        # A JSON-string that parses to dict should NOT be wrapped as list.
+        # Current behavior: fallback wraps as [original_string]. Alternative: raise.
+        # Document whichever the maintainer prefers; test reflects current behavior.
+        result = _coerce_list('{"a":"b"}')
+        assert result == ['{"a":"b"}']
+
+    def test_int_input_raises(self):
+        with pytest.raises(TypeError):
+            _coerce_list(42)
+
+
+class TestCoerceDict:
+    def test_native_dict_unchanged(self):
+        assert _coerce_dict({"a": 1}) == {"a": 1}
+
+    def test_empty_dict_unchanged(self):
+        assert _coerce_dict({}) == {}
+
+    def test_none_passes_through(self):
+        assert _coerce_dict(None) is None
+
+    def test_json_string_dict_coerced(self):
+        assert _coerce_dict('{"a":1,"b":"x"}') == {"a": 1, "b": "x"}
+
+    def test_invalid_json_raises(self):
+        # For dicts, we don't have a reasonable fallback — fail loudly.
+        with pytest.raises((TypeError, ValueError)):
+            _coerce_dict("not{valid]json")
+
+    def test_list_as_string_raises(self):
+        with pytest.raises((TypeError, ValueError)):
+            _coerce_dict('["a","b"]')
+
+
+class TestListStrAnnotated:
+    """Via Pydantic TypeAdapter — mirrors how FastMCP validates tool params."""
+
+    def setup_method(self):
+        self.adapter = TypeAdapter(ListStr)
+
+    def test_native_list_validates(self):
+        assert self.adapter.validate_python(["a", "b"]) == ["a", "b"]
+
+    def test_json_string_list_validates(self):
+        assert self.adapter.validate_python('["a","b"]') == ["a", "b"]
+
+    def test_none_validates(self):
+        assert self.adapter.validate_python(None) is None
+
+    def test_list_of_ints_rejected(self):
+        with pytest.raises(ValidationError):
+            self.adapter.validate_python([1, 2, 3])
+
+
+class TestDictAnyAnnotated:
+    def setup_method(self):
+        self.adapter = TypeAdapter(DictAny)
+
+    def test_native_dict_validates(self):
+        assert self.adapter.validate_python({"k": "v"}) == {"k": "v"}
+
+    def test_json_string_dict_validates(self):
+        assert self.adapter.validate_python('{"k":"v"}') == {"k": "v"}
+
+    def test_none_validates(self):
+        assert self.adapter.validate_python(None) is None
+
+
+class TestRegressionStoreMemorySignature:
+    """
+    Smoke test to ensure the store_memory tool accepts both input shapes.
+    Requires a fixture for the ogham store backend. Skip if no test store is wired.
+    """
+
+    @pytest.mark.skip(reason="Requires ogham store fixture; enable once wired.")
+    def test_store_memory_accepts_native_list(self, store):
+        # Placeholder for integration-style test against the actual tool.
+        pass
+
+    @pytest.mark.skip(reason="Requires ogham store fixture; enable once wired.")
+    def test_store_memory_accepts_stringified_list(self, store):
+        pass

--- a/tests/test_list_coercion.py
+++ b/tests/test_list_coercion.py
@@ -1,9 +1,8 @@
 """
-Tests for Conv 2.41 / KE-028 upstream fix: Annotated[T|None, BeforeValidator(coerce)]
-coercion wrappers on tool parameters in ogham/tools/memory.py.
-
-Drop this into the upstream tests/ directory (or ogham/tests/ — check upstream layout).
-Adjust imports once you've confirmed upstream's exact module path.
+Tests for the BeforeValidator-based list/dict coercion wrappers on tool
+parameters in ogham/tools/memory.py. These wrappers accept both native
+Python lists/dicts and their JSON-string forms, which some FastMCP clients
+emit before the transport layer.
 
 Run: pytest tests/test_list_coercion.py -v
 """


### PR DESCRIPTION
# Coerce stringified list/dict parameters for FastMCP client compatibility

## Summary

Some FastMCP clients serialize list/dict tool parameters as JSON strings before the transport layer rather than as native arrays/objects. When this happens, Pydantic on the server sees a `str` and fails `list_type` / `dict_type` validation, returning `-32602 Invalid params`. This PR adds a `BeforeValidator`-based coercion wrapper to the list and dict tool parameters in `ogham/tools/memory.py` so both native and stringified inputs validate correctly.

## Motivation

I hit this running ogham-mcp in a Claude Desktop + Cowork setup where the client stringifies `list[str]` parameters like `tags=["foo","bar"]` into the string `'["foo","bar"]'` before the MCP transport. Tool calls to `store_memory`, `list_recent`, `hybrid_search`, etc. would fail with a Pydantic `list_type` validation error wrapped in a JSON-RPC `-32602`.

Workarounds at the caller layer (inline-tag concatenation into content, pre-serialization, per-call JSON.stringify gymnastics) are brittle — they leak client-specific behavior into every caller. Fixing at the server with a small coercion wrapper is a one-time change that handles the inputs the current ecosystem actually produces.

## Approach

Wrap list[str] and dict[str, Any] tool parameters with `Annotated[T | None, BeforeValidator(coerce)]` where `coerce` accepts either the native shape or its JSON-string form and returns the canonical Python shape. BeforeValidator is the Pydantic 2.x-recommended path for pre-type-check coercion.

The pattern is consistent with upstream FastMCP itself — `fastmcp/utilities/components.py:82` uses the same idiom for its own version field.

### Coercion rules

| Input | list[str] | dict[str, Any] |
|---|---|---|
| Native (list / dict) | Pass through unchanged | Pass through unchanged |
| None | Pass through as None | Pass through as None |
| JSON string parsing to list/dict | Coerce to Python list/dict | Coerce to Python list/dict |
| Bare string (not JSON) | Fallback: wrap as `[s]` (pragmatic for tag-like fields) | Raise TypeError |
| Other types (int, etc.) | Raise TypeError | Raise TypeError |

The bare-string-to-list fallback is opinionated; happy to switch it to `raise` if you prefer strict semantics. I lean toward the current behavior because it matches how tag-like inputs show up in practice, but either is defensible.

## Backward compatibility

Zero-risk. All existing callers passing native `list` / `dict` behave identically — the new code path only activates when input is a `str`. No public signature changes; the `Annotated` wrappers are type-only and don't affect runtime arity.

## Test coverage

Added `tests/test_list_coercion.py` with a matrix covering:
- Native list/dict pass-through
- JSON-string coercion to list/dict
- None handling
- Bare-string fallback for lists
- Type-error raising for unsupported inputs
- Pydantic TypeAdapter validation (mirrors FastMCP's server-side validation path)

## Changes

- `ogham/tools/memory.py` — added `_coerce_list`, `_coerce_dict`, `ListStr`, `DictAny` helpers; wrapped 12 tool parameter signatures (10 list[str], 2 dict[str, Any])
- `tests/test_list_coercion.py` — new, coverage per above

## Alternatives considered

1. **Fix at the client.** Would require coordinating N clients; worse economics than fixing the server once.
2. **Fix at FastMCP.** Better long-term but requires protocol-level alignment with FastMCP maintainers and a breaking decision on client serialization. This PR is defensive and unblocks immediately; it can be deprecated if FastMCP upstreams a canonical fix.
3. **Custom Pydantic validator class.** More verbose for the same outcome; `BeforeValidator` is the idiomatic Pydantic 2.x path.

## Not in scope

- Changes to other tool modules (this PR only touches `ogham/tools/memory.py`). Happy to expand in a follow-up if the pattern is welcomed.
- Runtime telemetry for coercion events. Useful for debugging client stringification but adds noise; left out intentionally.

## Maintainer context note

Writing from a user-of-ogham-mcp perspective — this has been live on my side for a week with zero regressions and clean operation across native + stringified calls. Happy to adjust the fallback semantics, the helper placement, or the test shape if you'd prefer a different style. Not tied to any specific framing.

---

Related issue: will open a separate issue with the full failure-mode reproduction if you'd prefer that intake path before reviewing.
