### PR TITLE
feat: extend profile stats with health counters

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -635,36 +635,76 @@ as $$
 declare
     result jsonb;
 begin
-    select jsonb_build_object(
+    WITH active_memories AS (
+        SELECT id, source, tags, importance, last_accessed_at
+        FROM memories
+        WHERE profile = filter_profile
+          AND (expires_at IS NULL OR expires_at > now())
+    ),
+    relationship_presence AS (
+        SELECT source_id AS memory_id FROM memory_relationships
+        UNION
+        SELECT target_id AS memory_id FROM memory_relationships
+    ),
+    tag_rows AS (
+        SELECT unnest(tags) AS tag
+        FROM active_memories
+        WHERE tags IS NOT NULL AND cardinality(tags) > 0
+    )
+    SELECT jsonb_build_object(
         'profile', filter_profile,
-        'total', (
-            select count(*) from memories
-            where profile = filter_profile
-              and (expires_at is null or expires_at > now())
-        ),
-        'sources', (
-            select jsonb_object_agg(source, cnt)
-            from (
-                select coalesce(source, 'unknown') as source, count(*) as cnt
-                from memories
-                where profile = filter_profile
-                  and (expires_at is null or expires_at > now())
-                group by source
+        'total', (SELECT count(*) FROM active_memories),
+        'sources', COALESCE((
+            SELECT jsonb_object_agg(source, cnt)
+            FROM (
+                SELECT coalesce(source, 'unknown') AS source, count(*) AS cnt
+                FROM active_memories
+                GROUP BY coalesce(source, 'unknown')
             ) s
-        ),
-        'top_tags', (
-            select jsonb_agg(jsonb_build_object('tag', tag, 'count', cnt))
-            from (
-                select tag, count(*) as cnt
-                from memories, unnest(tags) as tag
-                where profile = filter_profile
-                  and (expires_at is null or expires_at > now())
-                group by tag
-                order by cnt desc
-                limit 20
+        ), '{}'::jsonb),
+        'top_tags', COALESCE((
+            SELECT jsonb_agg(jsonb_build_object('tag', tag, 'count', cnt))
+            FROM (
+                SELECT tag, count(*) AS cnt
+                FROM tag_rows
+                GROUP BY tag
+                ORDER BY cnt DESC, tag
+                LIMIT 20
             ) t
+        ), '[]'::jsonb),
+        'relationships', jsonb_build_object(
+            'orphan_count', (
+                SELECT count(*)
+                FROM active_memories m
+                LEFT JOIN relationship_presence rp ON rp.memory_id = m.id
+                WHERE rp.memory_id IS NULL
+            )
+        ),
+        'tagging', jsonb_build_object(
+            'untagged_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE tags IS NULL OR cardinality(tags) = 0
+            ),
+            'distinct_tag_count', (SELECT count(DISTINCT tag) FROM tag_rows)
+        ),
+        'decay', jsonb_build_object(
+            'eligible_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE importance > 0.05
+                  AND (
+                      last_accessed_at IS NULL
+                      OR last_accessed_at < now() - interval '7 days'
+                  )
+            ),
+            'floor_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE importance <= 0.05
+            )
         )
-    ) into result;
+    ) INTO result;
 
     return result;
 end;

--- a/sql/schema_postgres.sql
+++ b/sql/schema_postgres.sql
@@ -555,36 +555,76 @@ as $$
 declare
     result jsonb;
 begin
-    select jsonb_build_object(
+    WITH active_memories AS (
+        SELECT id, source, tags, importance, last_accessed_at
+        FROM memories
+        WHERE profile = filter_profile
+          AND (expires_at IS NULL OR expires_at > now())
+    ),
+    relationship_presence AS (
+        SELECT source_id AS memory_id FROM memory_relationships
+        UNION
+        SELECT target_id AS memory_id FROM memory_relationships
+    ),
+    tag_rows AS (
+        SELECT unnest(tags) AS tag
+        FROM active_memories
+        WHERE tags IS NOT NULL AND cardinality(tags) > 0
+    )
+    SELECT jsonb_build_object(
         'profile', filter_profile,
-        'total', (
-            select count(*) from memories
-            where profile = filter_profile
-              and (expires_at is null or expires_at > now())
-        ),
-        'sources', (
-            select jsonb_object_agg(source, cnt)
-            from (
-                select coalesce(source, 'unknown') as source, count(*) as cnt
-                from memories
-                where profile = filter_profile
-                  and (expires_at is null or expires_at > now())
-                group by source
+        'total', (SELECT count(*) FROM active_memories),
+        'sources', COALESCE((
+            SELECT jsonb_object_agg(source, cnt)
+            FROM (
+                SELECT coalesce(source, 'unknown') AS source, count(*) AS cnt
+                FROM active_memories
+                GROUP BY coalesce(source, 'unknown')
             ) s
-        ),
-        'top_tags', (
-            select jsonb_agg(jsonb_build_object('tag', tag, 'count', cnt))
-            from (
-                select tag, count(*) as cnt
-                from memories, unnest(tags) as tag
-                where profile = filter_profile
-                  and (expires_at is null or expires_at > now())
-                group by tag
-                order by cnt desc
-                limit 20
+        ), '{}'::jsonb),
+        'top_tags', COALESCE((
+            SELECT jsonb_agg(jsonb_build_object('tag', tag, 'count', cnt))
+            FROM (
+                SELECT tag, count(*) AS cnt
+                FROM tag_rows
+                GROUP BY tag
+                ORDER BY cnt DESC, tag
+                LIMIT 20
             ) t
+        ), '[]'::jsonb),
+        'relationships', jsonb_build_object(
+            'orphan_count', (
+                SELECT count(*)
+                FROM active_memories m
+                LEFT JOIN relationship_presence rp ON rp.memory_id = m.id
+                WHERE rp.memory_id IS NULL
+            )
+        ),
+        'tagging', jsonb_build_object(
+            'untagged_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE tags IS NULL OR cardinality(tags) = 0
+            ),
+            'distinct_tag_count', (SELECT count(DISTINCT tag) FROM tag_rows)
+        ),
+        'decay', jsonb_build_object(
+            'eligible_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE importance > 0.05
+                  AND (
+                      last_accessed_at IS NULL
+                      OR last_accessed_at < now() - interval '7 days'
+                  )
+            ),
+            'floor_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE importance <= 0.05
+            )
         )
-    ) into result;
+    ) INTO result;
 
     return result;
 end;

--- a/sql/schema_selfhost_supabase.sql
+++ b/sql/schema_selfhost_supabase.sql
@@ -605,36 +605,76 @@ as $$
 declare
     result jsonb;
 begin
-    select jsonb_build_object(
+    WITH active_memories AS (
+        SELECT id, source, tags, importance, last_accessed_at
+        FROM memories
+        WHERE profile = filter_profile
+          AND (expires_at IS NULL OR expires_at > now())
+    ),
+    relationship_presence AS (
+        SELECT source_id AS memory_id FROM memory_relationships
+        UNION
+        SELECT target_id AS memory_id FROM memory_relationships
+    ),
+    tag_rows AS (
+        SELECT unnest(tags) AS tag
+        FROM active_memories
+        WHERE tags IS NOT NULL AND cardinality(tags) > 0
+    )
+    SELECT jsonb_build_object(
         'profile', filter_profile,
-        'total', (
-            select count(*) from memories
-            where profile = filter_profile
-              and (expires_at is null or expires_at > now())
-        ),
-        'sources', (
-            select jsonb_object_agg(source, cnt)
-            from (
-                select coalesce(source, 'unknown') as source, count(*) as cnt
-                from memories
-                where profile = filter_profile
-                  and (expires_at is null or expires_at > now())
-                group by source
+        'total', (SELECT count(*) FROM active_memories),
+        'sources', COALESCE((
+            SELECT jsonb_object_agg(source, cnt)
+            FROM (
+                SELECT coalesce(source, 'unknown') AS source, count(*) AS cnt
+                FROM active_memories
+                GROUP BY coalesce(source, 'unknown')
             ) s
-        ),
-        'top_tags', (
-            select jsonb_agg(jsonb_build_object('tag', tag, 'count', cnt))
-            from (
-                select tag, count(*) as cnt
-                from memories, unnest(tags) as tag
-                where profile = filter_profile
-                  and (expires_at is null or expires_at > now())
-                group by tag
-                order by cnt desc
-                limit 20
+        ), '{}'::jsonb),
+        'top_tags', COALESCE((
+            SELECT jsonb_agg(jsonb_build_object('tag', tag, 'count', cnt))
+            FROM (
+                SELECT tag, count(*) AS cnt
+                FROM tag_rows
+                GROUP BY tag
+                ORDER BY cnt DESC, tag
+                LIMIT 20
             ) t
+        ), '[]'::jsonb),
+        'relationships', jsonb_build_object(
+            'orphan_count', (
+                SELECT count(*)
+                FROM active_memories m
+                LEFT JOIN relationship_presence rp ON rp.memory_id = m.id
+                WHERE rp.memory_id IS NULL
+            )
+        ),
+        'tagging', jsonb_build_object(
+            'untagged_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE tags IS NULL OR cardinality(tags) = 0
+            ),
+            'distinct_tag_count', (SELECT count(DISTINCT tag) FROM tag_rows)
+        ),
+        'decay', jsonb_build_object(
+            'eligible_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE importance > 0.05
+                  AND (
+                      last_accessed_at IS NULL
+                      OR last_accessed_at < now() - interval '7 days'
+                  )
+            ),
+            'floor_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE importance <= 0.05
+            )
         )
-    ) into result;
+    ) INTO result;
 
     return result;
 end;

--- a/src/ogham/sql/schema.sql
+++ b/src/ogham/sql/schema.sql
@@ -641,36 +641,76 @@ as $$
 declare
     result jsonb;
 begin
-    select jsonb_build_object(
+    WITH active_memories AS (
+        SELECT id, source, tags, importance, last_accessed_at
+        FROM memories
+        WHERE profile = filter_profile
+          AND (expires_at IS NULL OR expires_at > now())
+    ),
+    relationship_presence AS (
+        SELECT source_id AS memory_id FROM memory_relationships
+        UNION
+        SELECT target_id AS memory_id FROM memory_relationships
+    ),
+    tag_rows AS (
+        SELECT unnest(tags) AS tag
+        FROM active_memories
+        WHERE tags IS NOT NULL AND cardinality(tags) > 0
+    )
+    SELECT jsonb_build_object(
         'profile', filter_profile,
-        'total', (
-            select count(*) from memories
-            where profile = filter_profile
-              and (expires_at is null or expires_at > now())
-        ),
-        'sources', (
-            select jsonb_object_agg(source, cnt)
-            from (
-                select coalesce(source, 'unknown') as source, count(*) as cnt
-                from memories
-                where profile = filter_profile
-                  and (expires_at is null or expires_at > now())
-                group by source
+        'total', (SELECT count(*) FROM active_memories),
+        'sources', COALESCE((
+            SELECT jsonb_object_agg(source, cnt)
+            FROM (
+                SELECT coalesce(source, 'unknown') AS source, count(*) AS cnt
+                FROM active_memories
+                GROUP BY coalesce(source, 'unknown')
             ) s
-        ),
-        'top_tags', (
-            select jsonb_agg(jsonb_build_object('tag', tag, 'count', cnt))
-            from (
-                select tag, count(*) as cnt
-                from memories, unnest(tags) as tag
-                where profile = filter_profile
-                  and (expires_at is null or expires_at > now())
-                group by tag
-                order by cnt desc
-                limit 20
+        ), '{}'::jsonb),
+        'top_tags', COALESCE((
+            SELECT jsonb_agg(jsonb_build_object('tag', tag, 'count', cnt))
+            FROM (
+                SELECT tag, count(*) AS cnt
+                FROM tag_rows
+                GROUP BY tag
+                ORDER BY cnt DESC, tag
+                LIMIT 20
             ) t
+        ), '[]'::jsonb),
+        'relationships', jsonb_build_object(
+            'orphan_count', (
+                SELECT count(*)
+                FROM active_memories m
+                LEFT JOIN relationship_presence rp ON rp.memory_id = m.id
+                WHERE rp.memory_id IS NULL
+            )
+        ),
+        'tagging', jsonb_build_object(
+            'untagged_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE tags IS NULL OR cardinality(tags) = 0
+            ),
+            'distinct_tag_count', (SELECT count(DISTINCT tag) FROM tag_rows)
+        ),
+        'decay', jsonb_build_object(
+            'eligible_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE importance > 0.05
+                  AND (
+                      last_accessed_at IS NULL
+                      OR last_accessed_at < now() - interval '7 days'
+                  )
+            ),
+            'floor_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE importance <= 0.05
+            )
         )
-    ) into result;
+    ) INTO result;
 
     return result;
 end;

--- a/src/ogham/sql/schema_postgres.sql
+++ b/src/ogham/sql/schema_postgres.sql
@@ -554,36 +554,76 @@ as $$
 declare
     result jsonb;
 begin
-    select jsonb_build_object(
+    WITH active_memories AS (
+        SELECT id, source, tags, importance, last_accessed_at
+        FROM memories
+        WHERE profile = filter_profile
+          AND (expires_at IS NULL OR expires_at > now())
+    ),
+    relationship_presence AS (
+        SELECT source_id AS memory_id FROM memory_relationships
+        UNION
+        SELECT target_id AS memory_id FROM memory_relationships
+    ),
+    tag_rows AS (
+        SELECT unnest(tags) AS tag
+        FROM active_memories
+        WHERE tags IS NOT NULL AND cardinality(tags) > 0
+    )
+    SELECT jsonb_build_object(
         'profile', filter_profile,
-        'total', (
-            select count(*) from memories
-            where profile = filter_profile
-              and (expires_at is null or expires_at > now())
-        ),
-        'sources', (
-            select jsonb_object_agg(source, cnt)
-            from (
-                select coalesce(source, 'unknown') as source, count(*) as cnt
-                from memories
-                where profile = filter_profile
-                  and (expires_at is null or expires_at > now())
-                group by source
+        'total', (SELECT count(*) FROM active_memories),
+        'sources', COALESCE((
+            SELECT jsonb_object_agg(source, cnt)
+            FROM (
+                SELECT coalesce(source, 'unknown') AS source, count(*) AS cnt
+                FROM active_memories
+                GROUP BY coalesce(source, 'unknown')
             ) s
-        ),
-        'top_tags', (
-            select jsonb_agg(jsonb_build_object('tag', tag, 'count', cnt))
-            from (
-                select tag, count(*) as cnt
-                from memories, unnest(tags) as tag
-                where profile = filter_profile
-                  and (expires_at is null or expires_at > now())
-                group by tag
-                order by cnt desc
-                limit 20
+        ), '{}'::jsonb),
+        'top_tags', COALESCE((
+            SELECT jsonb_agg(jsonb_build_object('tag', tag, 'count', cnt))
+            FROM (
+                SELECT tag, count(*) AS cnt
+                FROM tag_rows
+                GROUP BY tag
+                ORDER BY cnt DESC, tag
+                LIMIT 20
             ) t
+        ), '[]'::jsonb),
+        'relationships', jsonb_build_object(
+            'orphan_count', (
+                SELECT count(*)
+                FROM active_memories m
+                LEFT JOIN relationship_presence rp ON rp.memory_id = m.id
+                WHERE rp.memory_id IS NULL
+            )
+        ),
+        'tagging', jsonb_build_object(
+            'untagged_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE tags IS NULL OR cardinality(tags) = 0
+            ),
+            'distinct_tag_count', (SELECT count(DISTINCT tag) FROM tag_rows)
+        ),
+        'decay', jsonb_build_object(
+            'eligible_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE importance > 0.05
+                  AND (
+                      last_accessed_at IS NULL
+                      OR last_accessed_at < now() - interval '7 days'
+                  )
+            ),
+            'floor_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE importance <= 0.05
+            )
         )
-    ) into result;
+    ) INTO result;
 
     return result;
 end;

--- a/src/ogham/sql/schema_selfhost_supabase.sql
+++ b/src/ogham/sql/schema_selfhost_supabase.sql
@@ -605,36 +605,76 @@ as $$
 declare
     result jsonb;
 begin
-    select jsonb_build_object(
+    WITH active_memories AS (
+        SELECT id, source, tags, importance, last_accessed_at
+        FROM memories
+        WHERE profile = filter_profile
+          AND (expires_at IS NULL OR expires_at > now())
+    ),
+    relationship_presence AS (
+        SELECT source_id AS memory_id FROM memory_relationships
+        UNION
+        SELECT target_id AS memory_id FROM memory_relationships
+    ),
+    tag_rows AS (
+        SELECT unnest(tags) AS tag
+        FROM active_memories
+        WHERE tags IS NOT NULL AND cardinality(tags) > 0
+    )
+    SELECT jsonb_build_object(
         'profile', filter_profile,
-        'total', (
-            select count(*) from memories
-            where profile = filter_profile
-              and (expires_at is null or expires_at > now())
-        ),
-        'sources', (
-            select jsonb_object_agg(source, cnt)
-            from (
-                select coalesce(source, 'unknown') as source, count(*) as cnt
-                from memories
-                where profile = filter_profile
-                  and (expires_at is null or expires_at > now())
-                group by source
+        'total', (SELECT count(*) FROM active_memories),
+        'sources', COALESCE((
+            SELECT jsonb_object_agg(source, cnt)
+            FROM (
+                SELECT coalesce(source, 'unknown') AS source, count(*) AS cnt
+                FROM active_memories
+                GROUP BY coalesce(source, 'unknown')
             ) s
-        ),
-        'top_tags', (
-            select jsonb_agg(jsonb_build_object('tag', tag, 'count', cnt))
-            from (
-                select tag, count(*) as cnt
-                from memories, unnest(tags) as tag
-                where profile = filter_profile
-                  and (expires_at is null or expires_at > now())
-                group by tag
-                order by cnt desc
-                limit 20
+        ), '{}'::jsonb),
+        'top_tags', COALESCE((
+            SELECT jsonb_agg(jsonb_build_object('tag', tag, 'count', cnt))
+            FROM (
+                SELECT tag, count(*) AS cnt
+                FROM tag_rows
+                GROUP BY tag
+                ORDER BY cnt DESC, tag
+                LIMIT 20
             ) t
+        ), '[]'::jsonb),
+        'relationships', jsonb_build_object(
+            'orphan_count', (
+                SELECT count(*)
+                FROM active_memories m
+                LEFT JOIN relationship_presence rp ON rp.memory_id = m.id
+                WHERE rp.memory_id IS NULL
+            )
+        ),
+        'tagging', jsonb_build_object(
+            'untagged_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE tags IS NULL OR cardinality(tags) = 0
+            ),
+            'distinct_tag_count', (SELECT count(DISTINCT tag) FROM tag_rows)
+        ),
+        'decay', jsonb_build_object(
+            'eligible_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE importance > 0.05
+                  AND (
+                      last_accessed_at IS NULL
+                      OR last_accessed_at < now() - interval '7 days'
+                  )
+            ),
+            'floor_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE importance <= 0.05
+            )
         )
-    ) into result;
+    ) INTO result;
 
     return result;
 end;

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -7,6 +7,8 @@ Run with:
 Skip with: uv run pytest -m 'not postgres_integration'
 """
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
 TEST_PROFILE = "_test_postgres"
@@ -32,6 +34,13 @@ pytestmark = [
     pytest.mark.postgres_integration,
     pytest.mark.skipif(not _can_connect(), reason="Postgres backend not configured or unreachable"),
 ]
+
+
+def _fake_embedding(value: float = 0.1) -> list[float]:
+    """Build a test embedding that matches the configured schema dimension."""
+    from ogham.config import settings
+
+    return [value] * settings.embedding_dim
 
 
 @pytest.fixture(autouse=True)
@@ -61,7 +70,7 @@ def test_store_and_retrieve():
     from ogham.database import get_backend
 
     backend = get_backend()
-    fake_emb = [0.1] * 768
+    fake_emb = _fake_embedding()
     result = backend.store_memory(
         content="test memory for postgres",
         embedding=fake_emb,
@@ -81,7 +90,7 @@ def test_search_memories():
     from ogham.database import get_backend
 
     backend = get_backend()
-    fake_emb = [0.1] * 768
+    fake_emb = _fake_embedding()
     backend.store_memory(
         content="searchable postgres memory",
         embedding=fake_emb,
@@ -102,7 +111,7 @@ def test_hybrid_search():
     from ogham.database import get_backend
 
     backend = get_backend()
-    fake_emb = [0.1] * 768
+    fake_emb = _fake_embedding()
     backend.store_memory(
         content="hybrid search postgres test",
         embedding=fake_emb,
@@ -122,7 +131,7 @@ def test_delete_memory():
     from ogham.database import get_backend
 
     backend = get_backend()
-    fake_emb = [0.1] * 768
+    fake_emb = _fake_embedding()
     mem = backend.store_memory(
         content="to be deleted",
         embedding=fake_emb,
@@ -139,7 +148,7 @@ def test_profile_stats():
     from ogham.database import get_backend
 
     backend = get_backend()
-    fake_emb = [0.1] * 768
+    fake_emb = _fake_embedding()
     backend.store_memory(
         content="stats test",
         embedding=fake_emb,
@@ -148,3 +157,94 @@ def test_profile_stats():
     )
     stats = backend.get_memory_stats(TEST_PROFILE)
     assert stats["total"] == 1
+
+
+def test_profile_stats_health_counters():
+    """get_memory_stats should return the additive health counters."""
+    from ogham.database import get_backend
+
+    backend = get_backend()
+    fake_emb = _fake_embedding()
+
+    linked_a = backend.store_memory(
+        content="linked memory A",
+        embedding=fake_emb,
+        profile=TEST_PROFILE,
+        tags=["alpha"],
+    )
+    linked_b = backend.store_memory(
+        content="linked memory B",
+        embedding=fake_emb,
+        profile=TEST_PROFILE,
+        tags=["beta"],
+    )
+    eligible = backend.store_memory(
+        content="eligible memory",
+        embedding=fake_emb,
+        profile=TEST_PROFILE,
+    )
+    floor = backend.store_memory(
+        content="floor memory",
+        embedding=fake_emb,
+        profile=TEST_PROFILE,
+    )
+
+    backend.create_relationship(
+        source_id=linked_a["id"],
+        target_id=linked_b["id"],
+        relationship="related",
+        strength=1.0,
+        created_by="test",
+    )
+
+    # The decay metric counts any active memory with importance > 0.05 that has
+    # never been accessed or was last accessed more than 7 days ago. Seed the
+    # linked fixtures as recently accessed so only the explicit decay fixture is
+    # eligible.
+    backend._execute(
+        """UPDATE memories
+           SET last_accessed_at = %(last_accessed_at)s
+           WHERE id = ANY(%(ids)s::uuid[]) AND profile = %(profile)s""",
+        {
+            "last_accessed_at": datetime.now(timezone.utc),
+            "ids": [linked_a["id"], linked_b["id"]],
+            "profile": TEST_PROFILE,
+        },
+        fetch="none",
+    )
+
+    stale_access = datetime.now(timezone.utc) - timedelta(days=8)
+    # Seed precise decay-state fixtures directly in SQL. The public update API
+    # intentionally does not expose `importance`.
+    backend._execute(
+        """UPDATE memories
+           SET importance = %(importance)s,
+               last_accessed_at = %(last_accessed_at)s
+           WHERE id = %(id)s AND profile = %(profile)s""",
+        {
+            "importance": 0.7,
+            "last_accessed_at": stale_access,
+            "id": eligible["id"],
+            "profile": TEST_PROFILE,
+        },
+        fetch="none",
+    )
+    backend._execute(
+        """UPDATE memories
+           SET importance = %(importance)s
+           WHERE id = %(id)s AND profile = %(profile)s""",
+        {
+            "importance": 0.05,
+            "id": floor["id"],
+            "profile": TEST_PROFILE,
+        },
+        fetch="none",
+    )
+
+    stats = backend.get_memory_stats(TEST_PROFILE)
+    assert stats["total"] == 4
+    assert stats["relationships"]["orphan_count"] == 2
+    assert stats["tagging"]["untagged_count"] == 2
+    assert stats["tagging"]["distinct_tag_count"] == 2
+    assert stats["decay"]["eligible_count"] == 1
+    assert stats["decay"]["floor_count"] == 1


### PR DESCRIPTION
## Why
`get_stats()` only exposed total count, sources, and top tags. That made it hard to answer basic profile-health questions without extra queries or Python-side scans.

This extends the existing SQL aggregation in `get_memory_stats_sql()` so the dashboard can also answer:
- how many memories are disconnected from the relationship graph
- how many memories are untagged
- how many memories are decay-eligible
- how many memories are already at the decay floor

## What changed
- extended `get_memory_stats_sql()` in all three schema variants with additive `relationships`, `tagging`, and `decay` sections
- mirrored the same SQL change into the packaged schema copies under `src/ogham/sql/`
- added a Postgres integration test for the new counters
- fixed stale Postgres test fixtures by generating fake embeddings at the configured schema dimension instead of hardcoding `768`

## Why this shape
- keep the existing API stable by adding keys to the existing JSON result
- keep the work in SQL, not Python, so profile stats stay one query instead of N+1 aggregation
- keep all counters scoped to active, non-expired memories so the dashboard stays internally consistent
- keep the first slice focused on directly useful health metrics instead of a wider speculative payload

## Trade-offs
- the SQL function is longer, but the complexity stays local to one aggregation boundary
- `orphan_count` currently means "no relationship rows at all", which is the simpler first definition
- schema duplication still exists; broader schema unification is out of scope here

## Future considerations
- unify schema sources so there is one canonical place to update `get_memory_stats_sql()`
- add more counters only when there is a concrete dashboard need
- handle the pre-existing Postgres pool thread shutdown warnings separately

## Validation
- run `ruff check` on `src` and `tests`
- run the regular non-integration pytest suite with the default Supabase-mocked path, making sure any previously exported Postgres env vars are unset first
- run the Postgres integration suite against a local dev Postgres with the project schema applied
- verify the new stats counters through a simple local Postgres smoke check using linked, untagged, decay-eligible, and floor-importance memories
