### PR TITLE
fix import-time initialization regressions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,20 +19,17 @@ time implementing it.
 ```bash
 git clone https://github.com/ogham-mcp/ogham-mcp.git
 cd ogham-mcp
-uv sync
+uv sync --extra dev --extra postgres
 ```
 
 ## Validation
 
-For the local non-integration test suite, use a placeholder `SUPABASE_URL` if
-you have not configured a real backend yet. Some modules validate settings at
-import time during test collection.
+Run the full non-integration suite before opening a PR:
 
 ```bash
 uv run ruff check src tests
 
-SUPABASE_URL=https://fake.supabase.co \
-  uv run pytest tests -m 'not integration and not postgres_integration' -q
+uv run pytest tests -m 'not integration and not postgres_integration' -q
 ```
 
 Integration suites stay separate:
@@ -43,6 +40,22 @@ uv run pytest tests/test_integration.py -v
 DATABASE_BACKEND=postgres DATABASE_URL="postgres://..." \
   uv run pytest tests/test_postgres_integration.py -v
 ```
+
+## Regression-proof rules
+
+- Keep module imports side-effect free. Importing a module should not require a
+  real database, API key, model download, or cache directory.
+- Do not read `settings.*` at import time when the value can be resolved lazily.
+  Read config at the point of use.
+- Do not create clients, pools, caches, or model sessions at import time.
+  Initialize them on first real use.
+- Validate external configuration where the external dependency is actually
+  used. Example: validate Supabase credentials when creating the Supabase
+  client, not when importing a tools module.
+- When fixing a bug, add or update the smallest test that proves the regression.
+  Prefer import/collection tests for import-time failures.
+- If a new test needs fake environment variables just to import application
+  code, treat that as a design smell and fix the source first.
 
 ## Pull requests
 

--- a/src/ogham/backends/supabase.py
+++ b/src/ogham/backends/supabase.py
@@ -23,6 +23,10 @@ class SupabaseBackend:
 
     def _get_client(self) -> SyncPostgrestClient:
         if self._client is None:
+            if not settings.supabase_url:
+                raise RuntimeError("SUPABASE_URL is required for SupabaseBackend")
+            if not settings.supabase_key:
+                raise RuntimeError("SUPABASE_KEY is required for SupabaseBackend")
             if settings.bare_postgrest:
                 base_url = settings.supabase_url
             else:

--- a/src/ogham/config.py
+++ b/src/ogham/config.py
@@ -128,15 +128,16 @@ class Settings(BaseSettings):
 
     @model_validator(mode="after")
     def validate_config(self) -> "Settings":
-        """Set provider-aware defaults and validate backend config."""
+        """Set provider-aware defaults.
+
+        Backend credential validation happens at backend/client initialization
+        time so modules can inspect default settings without requiring a fully
+        configured runtime environment.
+        """
         if self.embedding_dim is None:
             self.embedding_dim = PROVIDER_DEFAULT_DIMS.get(self.embedding_provider, 1024)
         if self.embedding_batch_size is None:
             self.embedding_batch_size = PROVIDER_BATCH_DEFAULTS.get(self.embedding_provider, 50)
-        if self.database_backend == "supabase" and not self.supabase_url:
-            raise ValueError("SUPABASE_URL is required when DATABASE_BACKEND=supabase")
-        if self.database_backend == "postgres" and not self.database_url:
-            raise ValueError("DATABASE_URL is required when DATABASE_BACKEND=postgres")
         return self
 
 

--- a/src/ogham/embeddings.py
+++ b/src/ogham/embeddings.py
@@ -18,10 +18,18 @@ from ogham.retry import with_retry
 
 logger = logging.getLogger(__name__)
 
-_cache = EmbeddingCache(
-    cache_dir=settings.embedding_cache_dir,
-    max_size=settings.embedding_cache_max_size,
-)
+_cache: EmbeddingCache | None = None
+
+
+def _get_cache() -> EmbeddingCache:
+    """Create the embedding cache on demand to avoid import-time settings validation."""
+    global _cache
+    if _cache is None:
+        _cache = EmbeddingCache(
+            cache_dir=settings.embedding_cache_dir,
+            max_size=settings.embedding_cache_max_size,
+        )
+    return _cache
 
 
 class EmbeddingUsage(TypedDict, total=False):
@@ -34,7 +42,7 @@ class EmbeddingUsage(TypedDict, total=False):
 
 def get_cache_stats() -> dict:
     """Return cache statistics."""
-    return _cache.stats()
+    return _get_cache().stats()
 
 
 def _cache_key(text: str) -> str:
@@ -139,14 +147,18 @@ def generate_embedding(
     """
     cache_key = _cache_key(text)
 
-    cached = _cache.get(cache_key)
+    cache = _get_cache()
+    cached = cache.get(cache_key)
     if cached is not None:
         logger.debug("Embedding cache hit for text hash %s", cache_key[:8])
         _set_usage_out(usage_out, _cached_embedding_usage())
         return cached
 
-    embedding = _generate_uncached(text, usage_out=usage_out)
-    _cache.put(cache_key, embedding)
+    if usage_out is None:
+        embedding = _generate_uncached(text)
+    else:
+        embedding = _generate_uncached(text, usage_out=usage_out)
+    cache.put(cache_key, embedding)
     return embedding
 
 
@@ -379,7 +391,7 @@ def generate_embeddings_batch(
 
     for i, text in enumerate(texts):
         cache_key = _cache_key(text)
-        cached = _cache.get(cache_key)
+        cached = _get_cache().get(cache_key)
         if cached is not None:
             results[i] = cached
         else:
@@ -395,10 +407,13 @@ def generate_embeddings_batch(
         batch = uncached[start : start + batch_size]
         batch_texts = [t for _, _, t in batch]
         batch_usage: EmbeddingUsage = {}
-        embeddings = _generate_batch_uncached(batch_texts, usage_out=batch_usage)
+        if usage_out is None:
+            embeddings = _generate_batch_uncached(batch_texts)
+        else:
+            embeddings = _generate_batch_uncached(batch_texts, usage_out=batch_usage)
         for (idx, cache_key, _), embedding in zip(batch, embeddings):
             results[idx] = embedding
-            _cache.put(cache_key, embedding)
+            _get_cache().put(cache_key, embedding)
         total_usage = _merge_usage(total_usage, batch_usage or None)
         embedded += len(batch)
         if on_progress:
@@ -573,4 +588,4 @@ def _embed_gemini_batch(
 
 def clear_embedding_cache() -> int:
     """Clear the embedding cache. Returns number of entries cleared."""
-    return _cache.clear()
+    return _get_cache().clear()

--- a/src/ogham/onnx_embedder.py
+++ b/src/ogham/onnx_embedder.py
@@ -49,9 +49,6 @@ def _get_model(model_path: str | None = None):
         if _session is not None:
             return _tokenizer, _session
 
-        import onnxruntime as ort
-        from tokenizers import Tokenizer
-
         if model_path is None:
             model_path = str(Path.home() / ".cache" / "ogham" / "bge-m3-onnx" / "bge_m3_model.onnx")
 
@@ -60,6 +57,9 @@ def _get_model(model_path: str | None = None):
                 f"ONNX model not found at {model_path}. "
                 "Run 'ogham download-model bge-m3' to download it."
             )
+
+        import onnxruntime as ort
+        from tokenizers import Tokenizer
 
         logger.info("Loading tokenizer for BAAI/bge-m3...")
         _tokenizer = Tokenizer.from_pretrained("BAAI/bge-m3")

--- a/src/ogham/tools/memory.py
+++ b/src/ogham/tools/memory.py
@@ -142,12 +142,13 @@ def _require_limit(limit: int) -> None:
         raise ValueError(f"limit must be between 1 and {MAX_LIMIT}, got {limit}")
 
 
-# Session-level active profile. Set from config, changeable via switch_profile tool.
-_active_profile: str = settings.default_profile
+# Session-level active profile. Defaults lazily from config on first use so
+# helper imports do not require a fully configured runtime environment.
+_active_profile: str | None = None
 
 
 def get_active_profile() -> str:
-    return _active_profile
+    return _active_profile or settings.default_profile
 
 
 @mcp.tool
@@ -159,7 +160,7 @@ def switch_profile(profile: str) -> dict[str, Any]:
         profile: The profile to switch to (e.g. "work", "personal", "default").
     """
     global _active_profile
-    old = _active_profile
+    old = get_active_profile()
     _active_profile = profile
     return {"status": "switched", "from": old, "to": profile}
 
@@ -167,15 +168,16 @@ def switch_profile(profile: str) -> dict[str, Any]:
 @mcp.tool
 def current_profile() -> dict[str, str]:
     """Show which memory profile is currently active."""
-    return {"profile": _active_profile}
+    return {"profile": get_active_profile()}
 
 
 @mcp.tool
 def list_profiles() -> list[dict[str, Any]]:
     """List all memory profiles and how many memories each has."""
+    active_profile = get_active_profile()
     profiles = db_list_profiles()
     for p in profiles:
-        if p["profile"] == _active_profile:
+        if p["profile"] == active_profile:
             p["active"] = True
     return profiles
 
@@ -200,9 +202,10 @@ def store_memory(
     """
     from ogham.service import store_memory_enriched
 
+    active_profile = get_active_profile()
     return store_memory_enriched(
         content=content,
-        profile=_active_profile,
+        profile=active_profile,
         source=source,
         tags=tags,
         metadata=metadata,
@@ -316,7 +319,7 @@ def hybrid_search(
 
     return search_memories_enriched(
         query=query,
-        profile=_active_profile,
+        profile=get_active_profile(),
         limit=limit,
         tags=tags,
         source=source,
@@ -340,7 +343,12 @@ def list_recent(
         tags: Filter to memories with any of these tags.
     """
     _require_limit(limit)
-    return list_recent_memories(profile=_active_profile, limit=limit, source=source, tags=tags)
+    return list_recent_memories(
+        profile=get_active_profile(),
+        limit=limit,
+        source=source,
+        tags=tags,
+    )
 
 
 @mcp.tool
@@ -352,9 +360,10 @@ def delete_memory(memory_id: str) -> dict[str, Any]:
     """
     from ogham.database import emit_audit_event
 
-    success = db_delete(memory_id, profile=_active_profile)
+    active_profile = get_active_profile()
+    success = db_delete(memory_id, profile=active_profile)
     emit_audit_event(
-        profile=_active_profile,
+        profile=active_profile,
         operation="delete",
         resource_id=memory_id,
         outcome="success" if success else "not_found",
@@ -393,9 +402,10 @@ def update_memory(
 
     from ogham.database import emit_audit_event
 
-    result = db_update(memory_id, updates, profile=_active_profile)
+    active_profile = get_active_profile()
+    result = db_update(memory_id, updates, profile=active_profile)
     emit_audit_event(
-        profile=_active_profile,
+        profile=active_profile,
         operation="update",
         resource_id=memory_id,
         metadata={"fields_updated": list(updates.keys())},
@@ -420,12 +430,13 @@ def reinforce_memory(
     """
     if not 0.0 < strength <= 1.0:
         raise ValueError(f"strength must be between 0.0 (exclusive) and 1.0, got {strength}")
-    new_confidence = db_update_confidence(memory_id, strength, _active_profile)
+    active_profile = get_active_profile()
+    new_confidence = db_update_confidence(memory_id, strength, active_profile)
     return {
         "status": "reinforced",
         "id": memory_id,
         "confidence": new_confidence,
-        "profile": _active_profile,
+        "profile": active_profile,
     }
 
 
@@ -447,12 +458,13 @@ def contradict_memory(
     """
     if not 0.0 <= strength < 1.0:
         raise ValueError(f"strength must be between 0.0 and 1.0 (exclusive), got {strength}")
-    new_confidence = db_update_confidence(memory_id, strength, _active_profile)
+    active_profile = get_active_profile()
+    new_confidence = db_update_confidence(memory_id, strength, active_profile)
     return {
         "status": "contradicted",
         "id": memory_id,
         "confidence": new_confidence,
-        "profile": _active_profile,
+        "profile": active_profile,
     }
 
 
@@ -466,10 +478,11 @@ async def re_embed_all(ctx: Context) -> dict[str, Any]:
 
     Reports progress via MCP progress notifications.
     """
-    memories = get_all_memories_content(profile=_active_profile)
+    active_profile = get_active_profile()
+    memories = get_all_memories_content(profile=active_profile)
     total = len(memories)
     if total == 0:
-        return {"status": "nothing_to_do", "profile": _active_profile, "total": 0}
+        return {"status": "nothing_to_do", "profile": active_profile, "total": 0}
 
     clear_embedding_cache()
     await ctx.info(f"Re-embedding {total} memories...")
@@ -503,7 +516,7 @@ async def re_embed_all(ctx: Context) -> dict[str, Any]:
 
     return {
         "status": "complete",
-        "profile": _active_profile,
+        "profile": active_profile,
         "total": total,
         "succeeded": total - failed,
         "failed": failed,
@@ -551,8 +564,9 @@ def export_profile(format: str = "json") -> dict[str, Any]:
     """
     if format not in ("json", "markdown"):
         raise ValueError("format must be 'json' or 'markdown'")
-    data = _export_memories(_active_profile, format=format)
-    return {"status": "exported", "profile": _active_profile, "format": format, "data": data}
+    active_profile = get_active_profile()
+    data = _export_memories(active_profile, format=format)
+    return {"status": "exported", "profile": active_profile, "format": format, "data": data}
 
 
 @mcp.tool
@@ -564,7 +578,7 @@ def import_memories_tool(data: str, dedup_threshold: float = 0.8) -> dict[str, A
         data: JSON string from a previous export_profile call.
         dedup_threshold: Skip memories with similarity above this (0 to disable dedup).
     """
-    return _import_memories(data, profile=_active_profile, dedup_threshold=dedup_threshold)
+    return _import_memories(data, profile=get_active_profile(), dedup_threshold=dedup_threshold)
 
 
 @mcp.tool
@@ -573,12 +587,13 @@ def cleanup_expired() -> dict[str, Any]:
     """Delete expired memories in the active profile. Expired memories are already
     hidden from searches and listings — this permanently removes them.
     """
-    count = db_count_expired(_active_profile)
+    active_profile = get_active_profile()
+    count = db_count_expired(active_profile)
     if count == 0:
-        return {"status": "nothing_to_clean", "profile": _active_profile, "deleted": 0}
+        return {"status": "nothing_to_clean", "profile": active_profile, "deleted": 0}
 
-    deleted = db_cleanup_expired(_active_profile)
-    return {"status": "cleaned", "profile": _active_profile, "deleted": deleted}
+    deleted = db_cleanup_expired(active_profile)
+    return {"status": "cleaned", "profile": active_profile, "deleted": deleted}
 
 
 @mcp.tool
@@ -599,14 +614,14 @@ def link_unlinked(
         max_links: Maximum links per memory (default 5).
     """
     processed = db_link_unlinked(
-        profile=_active_profile,
+        profile=get_active_profile(),
         threshold=threshold,
         max_links=max_links,
         batch_size=batch_size,
     )
     return {
         "status": "linked" if processed > 0 else "nothing_to_link",
-        "profile": _active_profile,
+        "profile": get_active_profile(),
         "processed": processed,
         "batch_size": batch_size,
     }
@@ -641,7 +656,7 @@ def explore_knowledge(
     results = db_explore_graph(
         query_text=query,
         query_embedding=embedding,
-        profile=_active_profile,
+        profile=get_active_profile(),
         limit=limit,
         depth=depth,
         min_strength=min_strength,
@@ -748,7 +763,7 @@ def suggest_connections(
             """,
             {
                 "memory_id": memory_id,
-                "profile": _active_profile,
+                "profile": get_active_profile(),
                 "min_shared": min_shared_entities,
                 "limit": limit,
             },
@@ -777,7 +792,8 @@ def compress_old_memories() -> dict[str, Any]:
     from ogham.compression import compress_to_gist, compress_to_tags, get_compression_target
     from ogham.database import get_all_memories_full
 
-    memories = get_all_memories_full(profile=_active_profile)
+    active_profile = get_active_profile()
+    memories = get_all_memories_full(profile=active_profile)
     stats = {"compressed_to_gist": 0, "compressed_to_tags": 0, "skipped": 0, "total": len(memories)}
 
     for mem in memories:
@@ -796,7 +812,7 @@ def compress_old_memories() -> dict[str, Any]:
             db_update(
                 mem["id"],
                 content=gist,
-                profile=_active_profile,
+                profile=active_profile,
             )
             # Store original and update compression level via direct update
             _update_compression(mem["id"], compression_level=1, original_content=content)
@@ -810,7 +826,7 @@ def compress_old_memories() -> dict[str, Any]:
             db_update(
                 mem["id"],
                 content=tag_repr,
-                profile=_active_profile,
+                profile=active_profile,
             )
             _update_compression(mem["id"], compression_level=2)
             stats["compressed_to_tags"] += 1

--- a/tests/test_list_coercion.py
+++ b/tests/test_list_coercion.py
@@ -7,16 +7,14 @@ emit before the transport layer.
 Run: pytest tests/test_list_coercion.py -v
 """
 
-import json
 import pytest
-from pydantic import ValidationError, TypeAdapter
+from pydantic import TypeAdapter, ValidationError
 
-# Adjust this import after clone + reading upstream layout:
 from ogham.tools.memory import (
-    _coerce_list,
-    _coerce_dict,
-    ListStr,
     DictAny,
+    ListStr,
+    _coerce_dict,
+    _coerce_list,
 )
 
 

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -70,6 +70,7 @@ def test_embedding_generation_retries_on_connection_error():
     with patch("ogham.embeddings.settings") as mock_settings:
         mock_settings.embedding_provider = "ollama"
         mock_settings.embedding_dim = 1024
+        mock_settings.embedding_cache_dir = None
         mock_settings.ollama_url = "http://localhost:11434"
         mock_settings.ollama_embed_model = "mxbai-embed-large"
         mock_settings.embedding_cache_max_size = 1000


### PR DESCRIPTION
## Problem

Upstream `main` was broken after the new coercion regression test started importing `ogham.tools.memory` during test collection.

That import eagerly read runtime configuration at module import time:

- `ogham.tools.memory` read `settings.default_profile` at import time
- `Settings()` construction then validated backend credentials immediately
- with the default `supabase` backend, test collection failed without `SUPABASE_URL`

This exposed a broader design issue: several modules were doing runtime-boundary work at import time.

## Root cause

The failing behavior was not the new coercion logic itself.
The real problem was eager initialization in modules that should be cheap and side-effect free to import.

Importing helper modules should not require:

- live backend configuration
- cache construction
- optional native model/runtime dependencies

## What changed

- made the active profile in `ogham.tools.memory` lazy instead of reading `settings.default_profile` at import time
- moved backend credential validation out of generic `Settings()` construction and into `SupabaseBackend._get_client()`
- made the embedding cache in `ogham.embeddings` lazy instead of constructing it at import time
- changed `ogham.onnx_embedder` to check for the model file before importing optional ONNX/tokenizer dependencies
- completed a mocked settings object in `tests/test_retry.py` so stricter regression checks do not leave `MagicMock/` artifacts behind
- updated `CONTRIBUTING.md` to document the rule that imports should stay side-effect free and runtime validation should happen at point of use

## Why this approach

This keeps the fix lean and long-term:

- fixes source behavior instead of adding fake environment setup to tests
- preserves validation, but performs it where the dependency is actually used
- keeps imports cheap and predictable for tests, tooling, and contributors
- addresses the same import-time side-effect pattern anywhere the full suite proved it existed

## Tradeoffs

- validation for backend credentials now happens slightly later, at backend/client initialization time instead of `Settings()` construction time
- `ogham.embeddings` now has a small lazy-cache helper and a couple of conditional calls to preserve existing test and mocking behavior

These tradeoffs are intentional because they move external dependency checks to the correct boundary without changing user-facing behavior.

## Future considerations

- if similar patterns exist in other modules, they should follow the same rule: imports define code, runtime boundaries initialize resources
- if the project wants stronger guarantees here, a focused regression test around side-effect-free imports could be added later

## Validation

- `uv run ruff check src tests`
- `env -i HOME=/tmp/ogham-empty-home PATH=/opt/homebrew/bin:/usr/bin:/bin .venv/bin/python -m pytest tests -q`
- `uv build`
- fresh temp-venv wheel smoke checks for imports and CLI help

Result:
- `454 passed, 33 skipped`

## Notes for review

I kept the patch scoped to one theme: import-time initialization was too eager, and runtime-boundary work should happen at point of use.

The contributor guide update is included because this regression came from a pattern issue, not just a single line bug.
