### PR TITLE
feat: extend profile stats with health counters

### DIFF
--- a/sql/migrations/022_profile_health_stats.sql
+++ b/sql/migrations/022_profile_health_stats.sql
@@ -1,0 +1,97 @@
+-- Migration 022: extend get_memory_stats_sql() with profile health counters.
+--
+-- Adds additive JSON fields for relationship, tagging, and decay health so
+-- existing installs get the same stats payload as fresh installs from the
+-- current schema snapshots.
+
+create or replace function get_memory_stats_sql(filter_profile text default 'default')
+returns jsonb
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+    result jsonb;
+begin
+    WITH active_memories AS (
+        SELECT id, source, tags, importance, last_accessed_at
+        FROM memories
+        WHERE profile = filter_profile
+          AND (expires_at IS NULL OR expires_at > now())
+    ),
+    related_active_memories AS (
+        SELECT mr.source_id AS memory_id
+        FROM memory_relationships mr
+        JOIN active_memories source_mem ON source_mem.id = mr.source_id
+        JOIN active_memories target_mem ON target_mem.id = mr.target_id
+        WHERE mr.source_id <> mr.target_id
+        UNION
+        SELECT mr.target_id AS memory_id
+        FROM memory_relationships mr
+        JOIN active_memories source_mem ON source_mem.id = mr.source_id
+        JOIN active_memories target_mem ON target_mem.id = mr.target_id
+        WHERE mr.source_id <> mr.target_id
+    ),
+    tag_rows AS (
+        SELECT unnest(tags) AS tag
+        FROM active_memories
+        WHERE tags IS NOT NULL AND cardinality(tags) > 0
+    )
+    SELECT jsonb_build_object(
+        'profile', filter_profile,
+        'total', (SELECT count(*) FROM active_memories),
+        'sources', COALESCE((
+            SELECT jsonb_object_agg(source, cnt)
+            FROM (
+                SELECT coalesce(source, 'unknown') AS source, count(*) AS cnt
+                FROM active_memories
+                GROUP BY coalesce(source, 'unknown')
+            ) s
+        ), '{}'::jsonb),
+        'top_tags', COALESCE((
+            SELECT jsonb_agg(jsonb_build_object('tag', tag, 'count', cnt))
+            FROM (
+                SELECT tag, count(*) AS cnt
+                FROM tag_rows
+                GROUP BY tag
+                ORDER BY cnt DESC, tag
+                LIMIT 20
+            ) t
+        ), '[]'::jsonb),
+        'relationships', jsonb_build_object(
+            'orphan_count', (
+                SELECT count(*)
+                FROM active_memories m
+                LEFT JOIN related_active_memories ram ON ram.memory_id = m.id
+                WHERE ram.memory_id IS NULL
+            )
+        ),
+        'tagging', jsonb_build_object(
+            'untagged_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE tags IS NULL OR cardinality(tags) = 0
+            ),
+            'distinct_tag_count', (SELECT count(DISTINCT tag) FROM tag_rows)
+        ),
+        'decay', jsonb_build_object(
+            'eligible_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE importance > 0.05
+                  AND (
+                      last_accessed_at IS NULL
+                      OR last_accessed_at < now() - interval '7 days'
+                  )
+            ),
+            'floor_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE importance <= 0.05
+            )
+        )
+    ) INTO result;
+
+    return result;
+end;
+$$;

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -635,36 +635,84 @@ as $$
 declare
     result jsonb;
 begin
-    select jsonb_build_object(
+    WITH active_memories AS (
+        SELECT id, source, tags, importance, last_accessed_at
+        FROM memories
+        WHERE profile = filter_profile
+          AND (expires_at IS NULL OR expires_at > now())
+    ),
+    related_active_memories AS (
+        SELECT mr.source_id AS memory_id
+        FROM memory_relationships mr
+        JOIN active_memories source_mem ON source_mem.id = mr.source_id
+        JOIN active_memories target_mem ON target_mem.id = mr.target_id
+        WHERE mr.source_id <> mr.target_id
+        UNION
+        SELECT mr.target_id AS memory_id
+        FROM memory_relationships mr
+        JOIN active_memories source_mem ON source_mem.id = mr.source_id
+        JOIN active_memories target_mem ON target_mem.id = mr.target_id
+        WHERE mr.source_id <> mr.target_id
+    ),
+    tag_rows AS (
+        SELECT unnest(tags) AS tag
+        FROM active_memories
+        WHERE tags IS NOT NULL AND cardinality(tags) > 0
+    )
+    SELECT jsonb_build_object(
         'profile', filter_profile,
-        'total', (
-            select count(*) from memories
-            where profile = filter_profile
-              and (expires_at is null or expires_at > now())
-        ),
-        'sources', (
-            select jsonb_object_agg(source, cnt)
-            from (
-                select coalesce(source, 'unknown') as source, count(*) as cnt
-                from memories
-                where profile = filter_profile
-                  and (expires_at is null or expires_at > now())
-                group by source
+        'total', (SELECT count(*) FROM active_memories),
+        'sources', COALESCE((
+            SELECT jsonb_object_agg(source, cnt)
+            FROM (
+                SELECT coalesce(source, 'unknown') AS source, count(*) AS cnt
+                FROM active_memories
+                GROUP BY coalesce(source, 'unknown')
             ) s
-        ),
-        'top_tags', (
-            select jsonb_agg(jsonb_build_object('tag', tag, 'count', cnt))
-            from (
-                select tag, count(*) as cnt
-                from memories, unnest(tags) as tag
-                where profile = filter_profile
-                  and (expires_at is null or expires_at > now())
-                group by tag
-                order by cnt desc
-                limit 20
+        ), '{}'::jsonb),
+        'top_tags', COALESCE((
+            SELECT jsonb_agg(jsonb_build_object('tag', tag, 'count', cnt))
+            FROM (
+                SELECT tag, count(*) AS cnt
+                FROM tag_rows
+                GROUP BY tag
+                ORDER BY cnt DESC, tag
+                LIMIT 20
             ) t
+        ), '[]'::jsonb),
+        'relationships', jsonb_build_object(
+            'orphan_count', (
+                SELECT count(*)
+                FROM active_memories m
+                LEFT JOIN related_active_memories ram ON ram.memory_id = m.id
+                WHERE ram.memory_id IS NULL
+            )
+        ),
+        'tagging', jsonb_build_object(
+            'untagged_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE tags IS NULL OR cardinality(tags) = 0
+            ),
+            'distinct_tag_count', (SELECT count(DISTINCT tag) FROM tag_rows)
+        ),
+        'decay', jsonb_build_object(
+            'eligible_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE importance > 0.05
+                  AND (
+                      last_accessed_at IS NULL
+                      OR last_accessed_at < now() - interval '7 days'
+                  )
+            ),
+            'floor_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE importance <= 0.05
+            )
         )
-    ) into result;
+    ) INTO result;
 
     return result;
 end;

--- a/sql/schema_postgres.sql
+++ b/sql/schema_postgres.sql
@@ -555,36 +555,84 @@ as $$
 declare
     result jsonb;
 begin
-    select jsonb_build_object(
+    WITH active_memories AS (
+        SELECT id, source, tags, importance, last_accessed_at
+        FROM memories
+        WHERE profile = filter_profile
+          AND (expires_at IS NULL OR expires_at > now())
+    ),
+    related_active_memories AS (
+        SELECT mr.source_id AS memory_id
+        FROM memory_relationships mr
+        JOIN active_memories source_mem ON source_mem.id = mr.source_id
+        JOIN active_memories target_mem ON target_mem.id = mr.target_id
+        WHERE mr.source_id <> mr.target_id
+        UNION
+        SELECT mr.target_id AS memory_id
+        FROM memory_relationships mr
+        JOIN active_memories source_mem ON source_mem.id = mr.source_id
+        JOIN active_memories target_mem ON target_mem.id = mr.target_id
+        WHERE mr.source_id <> mr.target_id
+    ),
+    tag_rows AS (
+        SELECT unnest(tags) AS tag
+        FROM active_memories
+        WHERE tags IS NOT NULL AND cardinality(tags) > 0
+    )
+    SELECT jsonb_build_object(
         'profile', filter_profile,
-        'total', (
-            select count(*) from memories
-            where profile = filter_profile
-              and (expires_at is null or expires_at > now())
-        ),
-        'sources', (
-            select jsonb_object_agg(source, cnt)
-            from (
-                select coalesce(source, 'unknown') as source, count(*) as cnt
-                from memories
-                where profile = filter_profile
-                  and (expires_at is null or expires_at > now())
-                group by source
+        'total', (SELECT count(*) FROM active_memories),
+        'sources', COALESCE((
+            SELECT jsonb_object_agg(source, cnt)
+            FROM (
+                SELECT coalesce(source, 'unknown') AS source, count(*) AS cnt
+                FROM active_memories
+                GROUP BY coalesce(source, 'unknown')
             ) s
-        ),
-        'top_tags', (
-            select jsonb_agg(jsonb_build_object('tag', tag, 'count', cnt))
-            from (
-                select tag, count(*) as cnt
-                from memories, unnest(tags) as tag
-                where profile = filter_profile
-                  and (expires_at is null or expires_at > now())
-                group by tag
-                order by cnt desc
-                limit 20
+        ), '{}'::jsonb),
+        'top_tags', COALESCE((
+            SELECT jsonb_agg(jsonb_build_object('tag', tag, 'count', cnt))
+            FROM (
+                SELECT tag, count(*) AS cnt
+                FROM tag_rows
+                GROUP BY tag
+                ORDER BY cnt DESC, tag
+                LIMIT 20
             ) t
+        ), '[]'::jsonb),
+        'relationships', jsonb_build_object(
+            'orphan_count', (
+                SELECT count(*)
+                FROM active_memories m
+                LEFT JOIN related_active_memories ram ON ram.memory_id = m.id
+                WHERE ram.memory_id IS NULL
+            )
+        ),
+        'tagging', jsonb_build_object(
+            'untagged_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE tags IS NULL OR cardinality(tags) = 0
+            ),
+            'distinct_tag_count', (SELECT count(DISTINCT tag) FROM tag_rows)
+        ),
+        'decay', jsonb_build_object(
+            'eligible_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE importance > 0.05
+                  AND (
+                      last_accessed_at IS NULL
+                      OR last_accessed_at < now() - interval '7 days'
+                  )
+            ),
+            'floor_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE importance <= 0.05
+            )
         )
-    ) into result;
+    ) INTO result;
 
     return result;
 end;

--- a/sql/schema_selfhost_supabase.sql
+++ b/sql/schema_selfhost_supabase.sql
@@ -605,36 +605,84 @@ as $$
 declare
     result jsonb;
 begin
-    select jsonb_build_object(
+    WITH active_memories AS (
+        SELECT id, source, tags, importance, last_accessed_at
+        FROM memories
+        WHERE profile = filter_profile
+          AND (expires_at IS NULL OR expires_at > now())
+    ),
+    related_active_memories AS (
+        SELECT mr.source_id AS memory_id
+        FROM memory_relationships mr
+        JOIN active_memories source_mem ON source_mem.id = mr.source_id
+        JOIN active_memories target_mem ON target_mem.id = mr.target_id
+        WHERE mr.source_id <> mr.target_id
+        UNION
+        SELECT mr.target_id AS memory_id
+        FROM memory_relationships mr
+        JOIN active_memories source_mem ON source_mem.id = mr.source_id
+        JOIN active_memories target_mem ON target_mem.id = mr.target_id
+        WHERE mr.source_id <> mr.target_id
+    ),
+    tag_rows AS (
+        SELECT unnest(tags) AS tag
+        FROM active_memories
+        WHERE tags IS NOT NULL AND cardinality(tags) > 0
+    )
+    SELECT jsonb_build_object(
         'profile', filter_profile,
-        'total', (
-            select count(*) from memories
-            where profile = filter_profile
-              and (expires_at is null or expires_at > now())
-        ),
-        'sources', (
-            select jsonb_object_agg(source, cnt)
-            from (
-                select coalesce(source, 'unknown') as source, count(*) as cnt
-                from memories
-                where profile = filter_profile
-                  and (expires_at is null or expires_at > now())
-                group by source
+        'total', (SELECT count(*) FROM active_memories),
+        'sources', COALESCE((
+            SELECT jsonb_object_agg(source, cnt)
+            FROM (
+                SELECT coalesce(source, 'unknown') AS source, count(*) AS cnt
+                FROM active_memories
+                GROUP BY coalesce(source, 'unknown')
             ) s
-        ),
-        'top_tags', (
-            select jsonb_agg(jsonb_build_object('tag', tag, 'count', cnt))
-            from (
-                select tag, count(*) as cnt
-                from memories, unnest(tags) as tag
-                where profile = filter_profile
-                  and (expires_at is null or expires_at > now())
-                group by tag
-                order by cnt desc
-                limit 20
+        ), '{}'::jsonb),
+        'top_tags', COALESCE((
+            SELECT jsonb_agg(jsonb_build_object('tag', tag, 'count', cnt))
+            FROM (
+                SELECT tag, count(*) AS cnt
+                FROM tag_rows
+                GROUP BY tag
+                ORDER BY cnt DESC, tag
+                LIMIT 20
             ) t
+        ), '[]'::jsonb),
+        'relationships', jsonb_build_object(
+            'orphan_count', (
+                SELECT count(*)
+                FROM active_memories m
+                LEFT JOIN related_active_memories ram ON ram.memory_id = m.id
+                WHERE ram.memory_id IS NULL
+            )
+        ),
+        'tagging', jsonb_build_object(
+            'untagged_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE tags IS NULL OR cardinality(tags) = 0
+            ),
+            'distinct_tag_count', (SELECT count(DISTINCT tag) FROM tag_rows)
+        ),
+        'decay', jsonb_build_object(
+            'eligible_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE importance > 0.05
+                  AND (
+                      last_accessed_at IS NULL
+                      OR last_accessed_at < now() - interval '7 days'
+                  )
+            ),
+            'floor_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE importance <= 0.05
+            )
         )
-    ) into result;
+    ) INTO result;
 
     return result;
 end;

--- a/src/ogham/sql/migrations/022_profile_health_stats.sql
+++ b/src/ogham/sql/migrations/022_profile_health_stats.sql
@@ -1,0 +1,97 @@
+-- Migration 022: extend get_memory_stats_sql() with profile health counters.
+--
+-- Adds additive JSON fields for relationship, tagging, and decay health so
+-- existing installs get the same stats payload as fresh installs from the
+-- current schema snapshots.
+
+create or replace function get_memory_stats_sql(filter_profile text default 'default')
+returns jsonb
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+    result jsonb;
+begin
+    WITH active_memories AS (
+        SELECT id, source, tags, importance, last_accessed_at
+        FROM memories
+        WHERE profile = filter_profile
+          AND (expires_at IS NULL OR expires_at > now())
+    ),
+    related_active_memories AS (
+        SELECT mr.source_id AS memory_id
+        FROM memory_relationships mr
+        JOIN active_memories source_mem ON source_mem.id = mr.source_id
+        JOIN active_memories target_mem ON target_mem.id = mr.target_id
+        WHERE mr.source_id <> mr.target_id
+        UNION
+        SELECT mr.target_id AS memory_id
+        FROM memory_relationships mr
+        JOIN active_memories source_mem ON source_mem.id = mr.source_id
+        JOIN active_memories target_mem ON target_mem.id = mr.target_id
+        WHERE mr.source_id <> mr.target_id
+    ),
+    tag_rows AS (
+        SELECT unnest(tags) AS tag
+        FROM active_memories
+        WHERE tags IS NOT NULL AND cardinality(tags) > 0
+    )
+    SELECT jsonb_build_object(
+        'profile', filter_profile,
+        'total', (SELECT count(*) FROM active_memories),
+        'sources', COALESCE((
+            SELECT jsonb_object_agg(source, cnt)
+            FROM (
+                SELECT coalesce(source, 'unknown') AS source, count(*) AS cnt
+                FROM active_memories
+                GROUP BY coalesce(source, 'unknown')
+            ) s
+        ), '{}'::jsonb),
+        'top_tags', COALESCE((
+            SELECT jsonb_agg(jsonb_build_object('tag', tag, 'count', cnt))
+            FROM (
+                SELECT tag, count(*) AS cnt
+                FROM tag_rows
+                GROUP BY tag
+                ORDER BY cnt DESC, tag
+                LIMIT 20
+            ) t
+        ), '[]'::jsonb),
+        'relationships', jsonb_build_object(
+            'orphan_count', (
+                SELECT count(*)
+                FROM active_memories m
+                LEFT JOIN related_active_memories ram ON ram.memory_id = m.id
+                WHERE ram.memory_id IS NULL
+            )
+        ),
+        'tagging', jsonb_build_object(
+            'untagged_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE tags IS NULL OR cardinality(tags) = 0
+            ),
+            'distinct_tag_count', (SELECT count(DISTINCT tag) FROM tag_rows)
+        ),
+        'decay', jsonb_build_object(
+            'eligible_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE importance > 0.05
+                  AND (
+                      last_accessed_at IS NULL
+                      OR last_accessed_at < now() - interval '7 days'
+                  )
+            ),
+            'floor_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE importance <= 0.05
+            )
+        )
+    ) INTO result;
+
+    return result;
+end;
+$$;

--- a/src/ogham/sql/schema.sql
+++ b/src/ogham/sql/schema.sql
@@ -641,36 +641,84 @@ as $$
 declare
     result jsonb;
 begin
-    select jsonb_build_object(
+    WITH active_memories AS (
+        SELECT id, source, tags, importance, last_accessed_at
+        FROM memories
+        WHERE profile = filter_profile
+          AND (expires_at IS NULL OR expires_at > now())
+    ),
+    related_active_memories AS (
+        SELECT mr.source_id AS memory_id
+        FROM memory_relationships mr
+        JOIN active_memories source_mem ON source_mem.id = mr.source_id
+        JOIN active_memories target_mem ON target_mem.id = mr.target_id
+        WHERE mr.source_id <> mr.target_id
+        UNION
+        SELECT mr.target_id AS memory_id
+        FROM memory_relationships mr
+        JOIN active_memories source_mem ON source_mem.id = mr.source_id
+        JOIN active_memories target_mem ON target_mem.id = mr.target_id
+        WHERE mr.source_id <> mr.target_id
+    ),
+    tag_rows AS (
+        SELECT unnest(tags) AS tag
+        FROM active_memories
+        WHERE tags IS NOT NULL AND cardinality(tags) > 0
+    )
+    SELECT jsonb_build_object(
         'profile', filter_profile,
-        'total', (
-            select count(*) from memories
-            where profile = filter_profile
-              and (expires_at is null or expires_at > now())
-        ),
-        'sources', (
-            select jsonb_object_agg(source, cnt)
-            from (
-                select coalesce(source, 'unknown') as source, count(*) as cnt
-                from memories
-                where profile = filter_profile
-                  and (expires_at is null or expires_at > now())
-                group by source
+        'total', (SELECT count(*) FROM active_memories),
+        'sources', COALESCE((
+            SELECT jsonb_object_agg(source, cnt)
+            FROM (
+                SELECT coalesce(source, 'unknown') AS source, count(*) AS cnt
+                FROM active_memories
+                GROUP BY coalesce(source, 'unknown')
             ) s
-        ),
-        'top_tags', (
-            select jsonb_agg(jsonb_build_object('tag', tag, 'count', cnt))
-            from (
-                select tag, count(*) as cnt
-                from memories, unnest(tags) as tag
-                where profile = filter_profile
-                  and (expires_at is null or expires_at > now())
-                group by tag
-                order by cnt desc
-                limit 20
+        ), '{}'::jsonb),
+        'top_tags', COALESCE((
+            SELECT jsonb_agg(jsonb_build_object('tag', tag, 'count', cnt))
+            FROM (
+                SELECT tag, count(*) AS cnt
+                FROM tag_rows
+                GROUP BY tag
+                ORDER BY cnt DESC, tag
+                LIMIT 20
             ) t
+        ), '[]'::jsonb),
+        'relationships', jsonb_build_object(
+            'orphan_count', (
+                SELECT count(*)
+                FROM active_memories m
+                LEFT JOIN related_active_memories ram ON ram.memory_id = m.id
+                WHERE ram.memory_id IS NULL
+            )
+        ),
+        'tagging', jsonb_build_object(
+            'untagged_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE tags IS NULL OR cardinality(tags) = 0
+            ),
+            'distinct_tag_count', (SELECT count(DISTINCT tag) FROM tag_rows)
+        ),
+        'decay', jsonb_build_object(
+            'eligible_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE importance > 0.05
+                  AND (
+                      last_accessed_at IS NULL
+                      OR last_accessed_at < now() - interval '7 days'
+                  )
+            ),
+            'floor_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE importance <= 0.05
+            )
         )
-    ) into result;
+    ) INTO result;
 
     return result;
 end;

--- a/src/ogham/sql/schema_postgres.sql
+++ b/src/ogham/sql/schema_postgres.sql
@@ -554,36 +554,84 @@ as $$
 declare
     result jsonb;
 begin
-    select jsonb_build_object(
+    WITH active_memories AS (
+        SELECT id, source, tags, importance, last_accessed_at
+        FROM memories
+        WHERE profile = filter_profile
+          AND (expires_at IS NULL OR expires_at > now())
+    ),
+    related_active_memories AS (
+        SELECT mr.source_id AS memory_id
+        FROM memory_relationships mr
+        JOIN active_memories source_mem ON source_mem.id = mr.source_id
+        JOIN active_memories target_mem ON target_mem.id = mr.target_id
+        WHERE mr.source_id <> mr.target_id
+        UNION
+        SELECT mr.target_id AS memory_id
+        FROM memory_relationships mr
+        JOIN active_memories source_mem ON source_mem.id = mr.source_id
+        JOIN active_memories target_mem ON target_mem.id = mr.target_id
+        WHERE mr.source_id <> mr.target_id
+    ),
+    tag_rows AS (
+        SELECT unnest(tags) AS tag
+        FROM active_memories
+        WHERE tags IS NOT NULL AND cardinality(tags) > 0
+    )
+    SELECT jsonb_build_object(
         'profile', filter_profile,
-        'total', (
-            select count(*) from memories
-            where profile = filter_profile
-              and (expires_at is null or expires_at > now())
-        ),
-        'sources', (
-            select jsonb_object_agg(source, cnt)
-            from (
-                select coalesce(source, 'unknown') as source, count(*) as cnt
-                from memories
-                where profile = filter_profile
-                  and (expires_at is null or expires_at > now())
-                group by source
+        'total', (SELECT count(*) FROM active_memories),
+        'sources', COALESCE((
+            SELECT jsonb_object_agg(source, cnt)
+            FROM (
+                SELECT coalesce(source, 'unknown') AS source, count(*) AS cnt
+                FROM active_memories
+                GROUP BY coalesce(source, 'unknown')
             ) s
-        ),
-        'top_tags', (
-            select jsonb_agg(jsonb_build_object('tag', tag, 'count', cnt))
-            from (
-                select tag, count(*) as cnt
-                from memories, unnest(tags) as tag
-                where profile = filter_profile
-                  and (expires_at is null or expires_at > now())
-                group by tag
-                order by cnt desc
-                limit 20
+        ), '{}'::jsonb),
+        'top_tags', COALESCE((
+            SELECT jsonb_agg(jsonb_build_object('tag', tag, 'count', cnt))
+            FROM (
+                SELECT tag, count(*) AS cnt
+                FROM tag_rows
+                GROUP BY tag
+                ORDER BY cnt DESC, tag
+                LIMIT 20
             ) t
+        ), '[]'::jsonb),
+        'relationships', jsonb_build_object(
+            'orphan_count', (
+                SELECT count(*)
+                FROM active_memories m
+                LEFT JOIN related_active_memories ram ON ram.memory_id = m.id
+                WHERE ram.memory_id IS NULL
+            )
+        ),
+        'tagging', jsonb_build_object(
+            'untagged_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE tags IS NULL OR cardinality(tags) = 0
+            ),
+            'distinct_tag_count', (SELECT count(DISTINCT tag) FROM tag_rows)
+        ),
+        'decay', jsonb_build_object(
+            'eligible_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE importance > 0.05
+                  AND (
+                      last_accessed_at IS NULL
+                      OR last_accessed_at < now() - interval '7 days'
+                  )
+            ),
+            'floor_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE importance <= 0.05
+            )
         )
-    ) into result;
+    ) INTO result;
 
     return result;
 end;

--- a/src/ogham/sql/schema_selfhost_supabase.sql
+++ b/src/ogham/sql/schema_selfhost_supabase.sql
@@ -605,36 +605,84 @@ as $$
 declare
     result jsonb;
 begin
-    select jsonb_build_object(
+    WITH active_memories AS (
+        SELECT id, source, tags, importance, last_accessed_at
+        FROM memories
+        WHERE profile = filter_profile
+          AND (expires_at IS NULL OR expires_at > now())
+    ),
+    related_active_memories AS (
+        SELECT mr.source_id AS memory_id
+        FROM memory_relationships mr
+        JOIN active_memories source_mem ON source_mem.id = mr.source_id
+        JOIN active_memories target_mem ON target_mem.id = mr.target_id
+        WHERE mr.source_id <> mr.target_id
+        UNION
+        SELECT mr.target_id AS memory_id
+        FROM memory_relationships mr
+        JOIN active_memories source_mem ON source_mem.id = mr.source_id
+        JOIN active_memories target_mem ON target_mem.id = mr.target_id
+        WHERE mr.source_id <> mr.target_id
+    ),
+    tag_rows AS (
+        SELECT unnest(tags) AS tag
+        FROM active_memories
+        WHERE tags IS NOT NULL AND cardinality(tags) > 0
+    )
+    SELECT jsonb_build_object(
         'profile', filter_profile,
-        'total', (
-            select count(*) from memories
-            where profile = filter_profile
-              and (expires_at is null or expires_at > now())
-        ),
-        'sources', (
-            select jsonb_object_agg(source, cnt)
-            from (
-                select coalesce(source, 'unknown') as source, count(*) as cnt
-                from memories
-                where profile = filter_profile
-                  and (expires_at is null or expires_at > now())
-                group by source
+        'total', (SELECT count(*) FROM active_memories),
+        'sources', COALESCE((
+            SELECT jsonb_object_agg(source, cnt)
+            FROM (
+                SELECT coalesce(source, 'unknown') AS source, count(*) AS cnt
+                FROM active_memories
+                GROUP BY coalesce(source, 'unknown')
             ) s
-        ),
-        'top_tags', (
-            select jsonb_agg(jsonb_build_object('tag', tag, 'count', cnt))
-            from (
-                select tag, count(*) as cnt
-                from memories, unnest(tags) as tag
-                where profile = filter_profile
-                  and (expires_at is null or expires_at > now())
-                group by tag
-                order by cnt desc
-                limit 20
+        ), '{}'::jsonb),
+        'top_tags', COALESCE((
+            SELECT jsonb_agg(jsonb_build_object('tag', tag, 'count', cnt))
+            FROM (
+                SELECT tag, count(*) AS cnt
+                FROM tag_rows
+                GROUP BY tag
+                ORDER BY cnt DESC, tag
+                LIMIT 20
             ) t
+        ), '[]'::jsonb),
+        'relationships', jsonb_build_object(
+            'orphan_count', (
+                SELECT count(*)
+                FROM active_memories m
+                LEFT JOIN related_active_memories ram ON ram.memory_id = m.id
+                WHERE ram.memory_id IS NULL
+            )
+        ),
+        'tagging', jsonb_build_object(
+            'untagged_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE tags IS NULL OR cardinality(tags) = 0
+            ),
+            'distinct_tag_count', (SELECT count(DISTINCT tag) FROM tag_rows)
+        ),
+        'decay', jsonb_build_object(
+            'eligible_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE importance > 0.05
+                  AND (
+                      last_accessed_at IS NULL
+                      OR last_accessed_at < now() - interval '7 days'
+                  )
+            ),
+            'floor_count', (
+                SELECT count(*)
+                FROM active_memories
+                WHERE importance <= 0.05
+            )
         )
-    ) into result;
+    ) INTO result;
 
     return result;
 end;

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -7,9 +7,12 @@ Run with:
 Skip with: uv run pytest -m 'not postgres_integration'
 """
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
 TEST_PROFILE = "_test_postgres"
+OTHER_PROFILE = "_test_postgres_other"
 
 
 def _can_connect() -> bool:
@@ -34,6 +37,13 @@ pytestmark = [
 ]
 
 
+def _fake_embedding(value: float = 0.1) -> list[float]:
+    """Build a test embedding that matches the configured schema dimension."""
+    from ogham.config import settings
+
+    return [value] * settings.embedding_dim
+
+
 @pytest.fixture(autouse=True)
 def cleanup():
     """Delete all test data after each test."""
@@ -46,10 +56,20 @@ def cleanup():
         {"p": TEST_PROFILE},
         fetch="none",
     )
+    backend._execute(
+        "DELETE FROM memories WHERE profile = %(p)s",
+        {"p": OTHER_PROFILE},
+        fetch="none",
+    )
     try:
         backend._execute(
             "DELETE FROM profile_settings WHERE profile = %(p)s",
             {"p": TEST_PROFILE},
+            fetch="none",
+        )
+        backend._execute(
+            "DELETE FROM profile_settings WHERE profile = %(p)s",
+            {"p": OTHER_PROFILE},
             fetch="none",
         )
     except Exception:
@@ -61,7 +81,7 @@ def test_store_and_retrieve():
     from ogham.database import get_backend
 
     backend = get_backend()
-    fake_emb = [0.1] * 768
+    fake_emb = _fake_embedding()
     result = backend.store_memory(
         content="test memory for postgres",
         embedding=fake_emb,
@@ -81,7 +101,7 @@ def test_search_memories():
     from ogham.database import get_backend
 
     backend = get_backend()
-    fake_emb = [0.1] * 768
+    fake_emb = _fake_embedding()
     backend.store_memory(
         content="searchable postgres memory",
         embedding=fake_emb,
@@ -102,7 +122,7 @@ def test_hybrid_search():
     from ogham.database import get_backend
 
     backend = get_backend()
-    fake_emb = [0.1] * 768
+    fake_emb = _fake_embedding()
     backend.store_memory(
         content="hybrid search postgres test",
         embedding=fake_emb,
@@ -122,7 +142,7 @@ def test_delete_memory():
     from ogham.database import get_backend
 
     backend = get_backend()
-    fake_emb = [0.1] * 768
+    fake_emb = _fake_embedding()
     mem = backend.store_memory(
         content="to be deleted",
         embedding=fake_emb,
@@ -139,7 +159,7 @@ def test_profile_stats():
     from ogham.database import get_backend
 
     backend = get_backend()
-    fake_emb = [0.1] * 768
+    fake_emb = _fake_embedding()
     backend.store_memory(
         content="stats test",
         embedding=fake_emb,
@@ -148,3 +168,111 @@ def test_profile_stats():
     )
     stats = backend.get_memory_stats(TEST_PROFILE)
     assert stats["total"] == 1
+
+
+def test_profile_stats_health_counters():
+    """get_memory_stats should return the additive health counters."""
+    from ogham.database import get_backend
+
+    backend = get_backend()
+    fake_emb = _fake_embedding()
+
+    linked_a = backend.store_memory(
+        content="linked memory A",
+        embedding=fake_emb,
+        profile=TEST_PROFILE,
+        tags=["alpha"],
+    )
+    linked_b = backend.store_memory(
+        content="linked memory B",
+        embedding=fake_emb,
+        profile=TEST_PROFILE,
+        tags=["beta"],
+    )
+    eligible = backend.store_memory(
+        content="eligible memory",
+        embedding=fake_emb,
+        profile=TEST_PROFILE,
+    )
+    cross_profile_only = backend.store_memory(
+        content="cross profile only memory",
+        embedding=fake_emb,
+        profile=TEST_PROFILE,
+    )
+    floor = backend.store_memory(
+        content="floor memory",
+        embedding=fake_emb,
+        profile=TEST_PROFILE,
+    )
+    other_profile = backend.store_memory(
+        content="other profile memory",
+        embedding=fake_emb,
+        profile=OTHER_PROFILE,
+    )
+
+    backend.create_relationship(
+        source_id=linked_a["id"],
+        target_id=linked_b["id"],
+        relationship="related",
+        strength=1.0,
+        created_by="test",
+    )
+    backend.create_relationship(
+        source_id=cross_profile_only["id"],
+        target_id=other_profile["id"],
+        relationship="related",
+        strength=1.0,
+        created_by="test",
+    )
+
+    # The decay metric counts any active memory with importance > 0.05 that has
+    # never been accessed or was last accessed more than 7 days ago. Seed the
+    # linked fixtures as recently accessed so only the explicit decay fixture is
+    # eligible.
+    backend._execute(
+        """UPDATE memories
+           SET last_accessed_at = %(last_accessed_at)s
+           WHERE id = ANY(%(ids)s::uuid[]) AND profile = %(profile)s""",
+        {
+            "last_accessed_at": datetime.now(timezone.utc),
+            "ids": [linked_a["id"], linked_b["id"]],
+            "profile": TEST_PROFILE,
+        },
+        fetch="none",
+    )
+
+    stale_access = datetime.now(timezone.utc) - timedelta(days=8)
+    # Seed precise decay-state fixtures directly in SQL. The public update API
+    # intentionally does not expose `importance`.
+    backend._execute(
+        """UPDATE memories
+           SET importance = %(importance)s,
+               last_accessed_at = %(last_accessed_at)s
+           WHERE id = %(id)s AND profile = %(profile)s""",
+        {
+            "importance": 0.7,
+            "last_accessed_at": stale_access,
+            "id": eligible["id"],
+            "profile": TEST_PROFILE,
+        },
+        fetch="none",
+    )
+    backend._execute(
+        """UPDATE memories
+           SET importance = %(importance)s
+           WHERE id = %(id)s AND profile = %(profile)s""",
+        {
+            "importance": 0.05,
+            "id": floor["id"],
+            "profile": TEST_PROFILE,
+        },
+        fetch="none",
+    )
+
+    stats = backend.get_memory_stats(TEST_PROFILE)
+    assert stats["total"] == 5
+    assert stats["relationships"]["orphan_count"] == 3
+    assert stats["tagging"]["untagged_count"] == 3
+    assert stats["tagging"]["distinct_tag_count"] == 2
+    assert stats["decay"]["eligible_count"] == 1
+    assert stats["decay"]["floor_count"] == 1


### PR DESCRIPTION
## Problem

`get_memory_stats_sql()` currently returns only the basic profile summary:

- `profile`
- `total`
- `sources`
- `top_tags`

That leaves the CLI and any other stats consumers without lightweight health signals about the state of a profile, such as:

- how many memories are disconnected from the in-profile relationship graph
- how many memories are untagged
- how many memories are currently eligible for Hebbian decay
- how many memories are already at the decay floor

Because these stats come from a SQL function, fresh installs and upgraded installs also need to stay in sync.

## What changed

- added migration `022_profile_health_stats.sql` to extend `get_memory_stats_sql()` for existing installs
- updated the schema snapshots under both `sql/` and `src/ogham/sql/` so fresh installs match the migrated function
- added new additive stats fields:
  - `relationships.orphan_count`
  - `tagging.untagged_count`
  - `tagging.distinct_tag_count`
  - `decay.eligible_count`
  - `decay.floor_count`
- updated the Postgres integration tests to cover the new counters
- replaced hardcoded integration-test embedding dimensions with a helper that follows the configured schema dimension

## Orphan count semantics

This PR intentionally tightens the meaning of `relationships.orphan_count`.

A memory counts as an orphan when it has **no relationship to another active memory in the same profile**.

That means:

- relationships to expired memories do not count
- relationships to memories in another profile do not count
- the metric reflects profile health for the profile being inspected, not whether a row exists anywhere in `memory_relationships`

A Postgres integration test now covers the cross-profile case explicitly.

## Why this approach

This keeps the change additive and low-risk:

- existing keys are preserved
- new fields are appended under new nested objects
- existing installs get the same output shape via migration
- fresh installs get the same output shape via updated schema snapshots

## Tradeoffs

- `get_memory_stats_sql()` is more complex because it now computes more derived counters in one call
- the repo still carries mirrored SQL snapshots, so this feature requires touching each mirrored schema file consistently
- live verification of the Postgres-specific behavior still depends on having a configured Postgres test database

These tradeoffs are acceptable because the payload stays backward compatible and the new counters are derived from existing data without introducing new tables or columns.

## Future considerations

- if more profile-health counters are added later, we may want to document the stats payload contract more explicitly
- if the project ever reduces duplicated schema snapshots, this class of SQL change will become cheaper to maintain

## Validation

Branch-specific validation for this SQL-focused change:

- `git diff --check main..HEAD`
- `uv run ruff check tests/test_postgres_integration.py`
- `uv run pytest tests/test_schema_parity.py tests/test_migration_integrity.py tests/test_postgres_integration.py -q`

Result:
- `9 passed, 6 skipped`

## Notes

This branch is intentionally independent of the separate import-time initialization fix PR.
