### PR TITLE
fix(cli): harden rich store/list renderers for UUID and datetime

### DIFF
--- a/src/ogham/cli.py
+++ b/src/ogham/cli.py
@@ -15,6 +15,11 @@ app = typer.Typer(
 console = Console()
 
 
+def _safe_text(value: object, limit: int | None = None) -> str:
+    text = "" if value is None else str(value)
+    return text[:limit] if limit is not None else text
+
+
 def _run_server(
     transport: str | None = None,
     host: str | None = None,
@@ -74,12 +79,15 @@ def store(
 
     console.print(f"[green]Stored memory {result['id']} in profile '{target}'[/green]")
     if result.get("expires_at"):
-        console.print(f"[dim]Expires: {result['expires_at'][:19]}[/dim]")
+        console.print(f"[dim]Expires: {_safe_text(result['expires_at'], 19)}[/dim]")
     if result.get("conflicts"):
         console.print(f"[yellow]{result['conflict_warning']}[/yellow]")
         for c in result["conflicts"]:
-            preview = c["content_preview"][:80]
-            console.print(f"  [dim]{c['id'][:8]}... ({c['similarity']:.0%}) {preview}[/dim]")
+            preview = _safe_text(c.get("content_preview", ""), 80)
+            similarity = float(c.get("similarity", 0))
+            console.print(
+                f"  [dim]{_safe_text(c.get('id'), 8)}... ({similarity:.0%}) {preview}[/dim]"
+            )
 
 
 @app.command()
@@ -284,11 +292,11 @@ def list_memories(
 
     for r in results:
         table.add_row(
-            str(r.get("id", ""))[:8],
-            r.get("created_at", "")[:19],
-            r["content"][:100],
+            _safe_text(r.get("id", ""), 8),
+            _safe_text(r.get("created_at", ""), 19),
+            _safe_text(r.get("content", ""), 100),
             ", ".join(r.get("tags", [])),
-            r.get("source", ""),
+            _safe_text(r.get("source", "")),
         )
 
     console.print(table)

--- a/tests/test_cli_rich_renderers.py
+++ b/tests/test_cli_rich_renderers.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from uuid import uuid4
+import sys
+
+from typer.testing import CliRunner
+
+from ogham import cli
+
+
+runner = CliRunner()
+
+
+def test_store_rich_output_handles_uuid_conflicts_and_datetime_expiry(monkeypatch) -> None:
+    monkeypatch.setattr(cli, "console", cli.Console(record=True))
+    monkeypatch.setitem(sys.modules, "ogham.config", SimpleNamespace(settings=SimpleNamespace(default_profile="default")))
+    monkeypatch.setitem(
+        sys.modules,
+        "ogham.service",
+        SimpleNamespace(
+            store_memory_enriched=lambda **_kwargs: {
+                "id": uuid4(),
+                "profile": "demo",
+                "expires_at": datetime.now(UTC),
+                "conflict_warning": "Found 1 existing memory(s) with >75% similarity.",
+                "conflicts": [
+                    {
+                        "id": uuid4(),
+                        "similarity": 1.0,
+                        "content_preview": "preview text",
+                    }
+                ],
+            }
+        ),
+    )
+
+    result = runner.invoke(cli.app, ["store", "content", "--profile", "demo"])
+
+    assert result.exit_code == 0
+    assert "Stored memory" in result.stdout
+    assert "Found 1 existing memory(s)" in result.stdout
+    assert "preview text" in result.stdout
+
+
+def test_list_rich_output_handles_datetime_created_at(monkeypatch) -> None:
+    monkeypatch.setattr(cli, "console", cli.Console(record=True))
+    monkeypatch.setitem(sys.modules, "ogham.config", SimpleNamespace(settings=SimpleNamespace(default_profile="default")))
+    monkeypatch.setitem(
+        sys.modules,
+        "ogham.database",
+        SimpleNamespace(
+            list_recent_memories=lambda **_kwargs: [
+                {
+                    "id": uuid4(),
+                    "created_at": datetime.now(UTC),
+                    "content": "memory content",
+                    "tags": ["tag-a"],
+                    "source": "unit-test",
+                }
+            ]
+        ),
+    )
+
+    result = runner.invoke(cli.app, ["list", "--profile", "demo", "--limit", "1"])
+
+    assert result.exit_code == 0
+    assert "Recent Memories" in result.stdout
+    assert "memory content" in result.stdout
+
+
+def test_store_json_output_remains_structured(monkeypatch) -> None:
+    monkeypatch.setitem(sys.modules, "ogham.config", SimpleNamespace(settings=SimpleNamespace(default_profile="default")))
+    monkeypatch.setitem(
+        sys.modules,
+        "ogham.service",
+        SimpleNamespace(
+            store_memory_enriched=lambda **_kwargs: {
+                "id": uuid4(),
+                "profile": "demo",
+                "expires_at": datetime.now(UTC),
+                "conflicts": [],
+            }
+        ),
+    )
+
+    result = runner.invoke(cli.app, ["store", "content", "--profile", "demo", "--json"])
+
+    assert result.exit_code == 0
+    assert '"profile": "demo"' in result.stdout


### PR DESCRIPTION
## Objetivo
Corrigir falhas do renderer rich do CLI em `store` e `list` quando campos chegam como tipos nativos (`UUID` / `datetime`), evitando erro de apresentacao apos persistencia bem-sucedida.

## Spec de referencia
N/A (upstream fix extraido de spec interna de memoria inter-agentes)

## Trilha Git
- Branch base: `main`
- Branch head: `main`
- Base SHA: upstream/main atual no clone local
- Head SHA: `34ede65`
- Gate interno: ADR-MCP-OGHAM-MEMORIA-INTER-AGENTES

## Escopo
- adicionar helper `_safe_text(...)` no CLI
- endurecer renderizacao rich de `store`
- endurecer renderizacao rich de `list`
- adicionar testes de regressao para `UUID` / `datetime`
- preservar `--json` como saida estruturada

## Fora de escopo
- mudancas no pipeline de storage
- mudancas no backend de embeddings/database
- alteracoes comportamentais fora do renderer CLI
- pin/distribuicao da versao downstream

## Arquivos impactados
- `src/ogham/cli.py`
- `tests/test_cli_rich_renderers.py`

## Artefatos SDD
- Plan: N/A
- Verification: N/A
- Write-back: N/A

## Riscos
- baixo risco: alteracao localizada no renderer CLI
- principal cuidado e manter compatibilidade do modo `--json`
- testes adicionados cobrem rich output e saida estruturada

## Testes
- `PYTHONPATH=src pytest -q tests/test_cli_rich_renderers.py` -> `3 passed`

## Validacao obrigatoria
- Python lint: `TS: N/A`
- Python testes: `PYTHONPATH=src pytest -q tests/test_cli_rich_renderers.py` -> `3 passed`
- TypeScript typecheck (se alterou `agent-contracts/`): `TS: N/A`
- TypeScript lint (se alterou `agent-contracts/`): `TS: N/A`
- TypeScript testes (se alterou `agent-contracts/`): `TS: N/A`

## Rollback
Reverter o commit `34ede65` ou remover o helper `_safe_text(...)` e os testes adicionados.
