### PR TITLE
chore: add pyright quality gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: Quality
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint-type-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v6.0.0
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 # v5.4.2
+
+      - name: Install dependencies
+        run: uv sync --extra dev --extra postgres
+
+      - name: Ruff
+        run: |
+          uv run ruff check src/ tests/
+          uv run ruff format --check src/ tests/
+
+      - name: Pyright
+        run: uv run pyright
+
+      - name: Tests
+        env:
+          DATABASE_BACKEND: supabase
+          SUPABASE_URL: https://fake.supabase.co
+          SUPABASE_KEY: fake-key
+          EMBEDDING_PROVIDER: ollama
+          DEFAULT_PROFILE: default
+        run: uv run pytest tests/ -m "not integration and not postgres_integration"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,11 @@ repos:
     rev: v8.21.2
     hooks:
       - id: gitleaks
+
+  - repo: local
+    hooks:
+      - id: pyright
+        name: pyright
+        entry: uv run pyright
+        language: system
+        pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ test:
 lint:
 	uv run ruff check src/ tests/
 	uv run ruff format --check src/ tests/
+	uv run pyright
 
 # Clean build artifacts
 clean:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8.0", "pytest-asyncio>=0.24", "ruff>=0.9"]
+dev = ["pytest>=8.0", "pytest-asyncio>=0.24", "ruff>=0.9", "pyright>=1.1.409"]
 postgres = [
     "psycopg-pool>=3.1",
     "psycopg[binary]>=3.1",
@@ -69,4 +69,5 @@ build-backend = "hatchling.build"
 [dependency-groups]
 dev = [
     "matplotlib>=3.10.8",
+    "pyright>=1.1.409",
 ]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,18 @@
+{
+    "include": ["src", "tests"],
+    "exclude": [
+        "benchmarks",
+        "dist",
+        ".venv",
+        "src/ogham/exporters/obsidian.py",
+        "src/ogham/recompute.py",
+        "src/ogham/topic_summaries.py",
+        "src/ogham/wiki_lint.py",
+    ],
+    "pythonVersion": "3.13",
+    "typeCheckingMode": "standard",
+    "venvPath": ".",
+    "venv": ".venv",
+    "reportMissingImports": "warning",
+    "reportMissingModuleSource": "warning",
+}

--- a/src/ogham/backends/gateway.py
+++ b/src/ogham/backends/gateway.py
@@ -275,7 +275,7 @@ class GatewayBackend:
     def count_decay_eligible(self, profile: str) -> int:
         return 0
 
-    def emit_audit_event(self, **kwargs: Any) -> None:
+    def emit_audit_event(self, *args: Any, **kwargs: Any) -> None:
         pass  # Gateway handles its own audit server-side
 
     def query_audit_log(

--- a/src/ogham/backends/postgres.py
+++ b/src/ogham/backends/postgres.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import contextvars
 import logging
 import os
+from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Any
+from typing import Any, Literal, LiteralString, overload
 
+from psycopg import Connection
 from psycopg.rows import dict_row
 from psycopg.types.json import Jsonb
 from psycopg_pool import ConnectionPool
@@ -95,9 +97,9 @@ class PostgresBackend:
     """DatabaseBackend implementation using psycopg + connection pool."""
 
     def __init__(self) -> None:
-        self._pool: ConnectionPool | None = None
+        self._pool: ConnectionPool[Connection[Any]] | None = None
 
-    def _get_pool(self) -> ConnectionPool:
+    def _get_pool(self) -> ConnectionPool[Connection[Any]]:
         if self._pool is None:
             if not settings.database_url:
                 raise RuntimeError("DATABASE_URL is required for PostgresBackend")
@@ -116,7 +118,7 @@ class PostgresBackend:
         Runs on first connection so upgraders don't need manual migrations.
         All statements use IF NOT EXISTS -- safe to run repeatedly.
         """
-        migrations = [
+        migrations: list[LiteralString] = [
             # v0.7.0: importance, surprise, compression
             "ALTER TABLE memories ADD COLUMN IF NOT EXISTS importance real DEFAULT 0.5",
             "ALTER TABLE memories ADD COLUMN IF NOT EXISTS surprise real DEFAULT 0.5",
@@ -127,7 +129,10 @@ class PostgresBackend:
             "ALTER TABLE memories ADD COLUMN IF NOT EXISTS recurrence_days integer[]",
         ]
         try:
-            with self._pool.connection() as conn:  # type: ignore[union-attr]
+            pool = self._pool
+            if pool is None:
+                return
+            with pool.connection() as conn:
                 for sql in migrations:
                     conn.execute(sql)
                 conn.commit()
@@ -139,7 +144,7 @@ class PostgresBackend:
     # ── Helper ────────────────────────────────────────────────────────
 
     @contextmanager
-    def _checkout(self):
+    def _checkout(self) -> Iterator[Connection[Any]]:
         """Check out a connection from the pool with tenant context applied.
 
         If `set_tenant_context()` has been called on the current task /
@@ -161,6 +166,42 @@ class PostgresBackend:
                 )
             yield conn
 
+    @overload
+    def _execute(
+        self,
+        query: str,
+        params: dict[str, Any] | None = None,
+        *,
+        fetch: Literal["all"] = "all",
+    ) -> list[dict[str, Any]]: ...
+
+    @overload
+    def _execute(
+        self,
+        query: str,
+        params: dict[str, Any] | None = None,
+        *,
+        fetch: Literal["one"],
+    ) -> dict[str, Any] | None: ...
+
+    @overload
+    def _execute(
+        self,
+        query: str,
+        params: dict[str, Any] | None = None,
+        *,
+        fetch: Literal["scalar"],
+    ) -> Any: ...
+
+    @overload
+    def _execute(
+        self,
+        query: str,
+        params: dict[str, Any] | None = None,
+        *,
+        fetch: Literal["none"],
+    ) -> None: ...
+
     def _execute(
         self,
         query: str,
@@ -175,7 +216,7 @@ class PostgresBackend:
         """
         with self._checkout() as conn:
             with conn.cursor() as cur:
-                cur.execute(query, params)
+                cur.execute(query.encode(), params)
                 if fetch == "none":
                     return None
                 if fetch == "scalar":
@@ -309,7 +350,7 @@ class PostgresBackend:
         results: list[dict[str, Any]] = []
         with self._checkout() as conn:
             with conn.cursor() as cur:
-                cur.execute(sql, params)
+                cur.execute(sql.encode(), params)
                 for result in cur.fetchall():
                     result.pop("embedding", None)
                     result.pop("fts", None)
@@ -690,6 +731,8 @@ class PostgresBackend:
             {"profile": profile, "ttl_days": ttl_days},
             fetch="one",
         )
+        if row is None:
+            raise RuntimeError("UPSERT returned no data for profile_settings")
         return row
 
     def cleanup_expired(self, profile: str) -> int:

--- a/src/ogham/backends/protocol.py
+++ b/src/ogham/backends/protocol.py
@@ -23,6 +23,8 @@ class DatabaseBackend(Protocol):
         source: str | None = None,
         tags: list[str] | None = None,
         expires_at: str | None = None,
+        importance: float = 0.5,
+        surprise: float = 0.5,
         recurrence_days: list[int] | None = None,
     ) -> dict[str, Any]: ...
 
@@ -209,7 +211,21 @@ class DatabaseBackend(Protocol):
 
     # ── Audit ────────────────────────────────────────────────────────
 
-    def emit_audit_event(self, **kwargs: Any) -> None: ...
+    def emit_audit_event(
+        self,
+        profile: str,
+        operation: str,
+        resource_id: str | None = None,
+        outcome: str = "success",
+        source: str | None = None,
+        embedding_model: str | None = None,
+        tokens_used: int | None = None,
+        cost_usd: float | None = None,
+        result_ids: list[str] | None = None,
+        result_count: int | None = None,
+        query_hash: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None: ...
 
     def query_audit_log(
         self,

--- a/src/ogham/backends/supabase.py
+++ b/src/ogham/backends/supabase.py
@@ -1,7 +1,8 @@
 """Supabase backend — wraps PostgREST directly (no supabase SDK needed)."""
 
 import logging
-from typing import Any
+from collections.abc import Mapping
+from typing import Any, cast
 
 from postgrest import SyncPostgrestClient
 
@@ -9,6 +10,20 @@ from ogham.config import settings
 from ogham.retry import with_retry
 
 logger = logging.getLogger(__name__)
+
+
+def _rows(data: Any) -> list[dict[str, Any]]:
+    if data is None:
+        return []
+    if not isinstance(data, list):
+        raise TypeError(f"Expected PostgREST list response, got {type(data).__name__}")
+    return [_row(item) for item in data]
+
+
+def _row(data: Any) -> dict[str, Any]:
+    if not isinstance(data, Mapping):
+        raise TypeError(f"Expected PostgREST row response, got {type(data).__name__}")
+    return {str(key): value for key, value in data.items()}
 
 
 class SupabaseBackend:
@@ -79,7 +94,7 @@ class SupabaseBackend:
             raise RuntimeError(
                 "Insert returned no data — check Supabase connection and table permissions"
             )
-        return result.data[0]
+        return _rows(result.data)[0]
 
     def store_memories_batch(self, rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
         if not rows:
@@ -89,7 +104,7 @@ class SupabaseBackend:
             raise RuntimeError(
                 "Batch insert returned no data — check Supabase connection and table permissions"
             )
-        return result.data
+        return _rows(result.data)
 
     @with_retry(max_attempts=2, base_delay=0.3)
     def search_memories(
@@ -113,7 +128,7 @@ class SupabaseBackend:
             params["filter_source"] = source
 
         result = self._get_client().rpc("match_memories", params).execute()
-        return result.data
+        return _rows(result.data)
 
     @with_retry(max_attempts=2, base_delay=0.3)
     def batch_check_duplicates(
@@ -130,7 +145,7 @@ class SupabaseBackend:
             "filter_profile": profile,
         }
         result = self._get_client().rpc("batch_check_duplicates", params).execute()
-        return result.data
+        return cast(list[bool], result.data)
 
     @with_retry(max_attempts=2, base_delay=0.3)
     def hybrid_search_memories(
@@ -161,7 +176,7 @@ class SupabaseBackend:
             params["filter_profiles"] = profiles
 
         result = self._get_client().rpc("hybrid_search_memories", params).execute()
-        return result.data
+        return _rows(result.data)
 
     @with_retry(max_attempts=2, base_delay=0.3)
     def list_recent_memories(
@@ -186,7 +201,7 @@ class SupabaseBackend:
         if tags:
             query = query.overlaps("tags", tags)
         result = query.order("created_at", desc=True).limit(limit).execute()
-        return result.data
+        return _rows(result.data)
 
     @with_retry(max_attempts=2, base_delay=0.3)
     def get_memory_stats(self, profile: str) -> dict[str, Any]:
@@ -196,8 +211,8 @@ class SupabaseBackend:
         if not result.data:
             return {"profile": profile, "total": 0, "sources": {}, "top_tags": []}
         if isinstance(result.data, dict):
-            return result.data
-        return result.data[0]
+            return _row(result.data)
+        return _rows(result.data)[0]
 
     @with_retry(max_attempts=2, base_delay=0.3)
     def get_all_memories_full(self, profile: str) -> list[dict[str, Any]]:
@@ -223,12 +238,13 @@ class SupabaseBackend:
                     f"and(created_at.eq.{last_created_at},id.gt.{last_id})"
                 )
             result = query.order("created_at").order("id").limit(batch).execute()
-            rows.extend(result.data)
-            if len(result.data) < batch:
+            page = _rows(result.data)
+            rows.extend(page)
+            if len(page) < batch:
                 break
-            last_row = result.data[-1]
-            last_created_at = last_row["created_at"]
-            last_id = last_row["id"]
+            last_row = page[-1]
+            last_created_at = str(last_row["created_at"])
+            last_id = str(last_row["id"])
         return rows
 
     @with_retry(max_attempts=2, base_delay=0.3)
@@ -243,42 +259,39 @@ class SupabaseBackend:
             if last_id is not None:
                 query = query.gt("id", last_id)
             result = query.order("id").limit(batch).execute()
-            rows.extend(result.data)
-            if len(result.data) < batch:
+            page = _rows(result.data)
+            rows.extend(page)
+            if len(page) < batch:
                 break
-            last_id = result.data[-1]["id"]
+            last_id = str(page[-1]["id"])
         return rows
 
     @with_retry(max_attempts=2, base_delay=0.3)
     def list_profiles(self) -> list[dict[str, Any]]:
         result = self._get_client().rpc("get_profile_counts", {}).execute()
-        return result.data
+        return _rows(result.data)
 
     def batch_update_embeddings(self, ids: list[str], embeddings: list[list[float]]) -> int:
-        result = (
-            self._get_client()
-            .rpc(
-                "batch_update_embeddings",
-                {"memory_ids": ids, "new_embeddings": [str(e) for e in embeddings]},
-            )
-            .execute()
-        )
+        params: dict[str, Any] = {
+            "memory_ids": ids,
+            "new_embeddings": [str(e) for e in embeddings],
+        }
+        result = self._get_client().rpc("batch_update_embeddings", params).execute()
         return result.data if isinstance(result.data, int) else 0
 
     def record_access(self, memory_ids: list[str]) -> None:
         if not memory_ids:
             return
-        self._get_client().rpc("record_access", {"memory_ids": memory_ids}).execute()
+        params: dict[str, Any] = {"memory_ids": memory_ids}
+        self._get_client().rpc("record_access", params).execute()
 
     def update_confidence(self, memory_id: str, signal: float, profile: str) -> float:
-        result = (
-            self._get_client()
-            .rpc(
-                "update_confidence",
-                {"memory_id": memory_id, "signal": signal, "memory_profile": profile},
-            )
-            .execute()
-        )
+        params: dict[str, Any] = {
+            "memory_id": memory_id,
+            "signal": signal,
+            "memory_profile": profile,
+        }
+        result = self._get_client().rpc("update_confidence", params).execute()
         return result.data if isinstance(result.data, float) else 0.5
 
     def get_memory_by_id(self, memory_id: str, profile: str) -> dict[str, Any] | None:
@@ -292,7 +305,7 @@ class SupabaseBackend:
         )
         if not result.data:
             return None
-        row = result.data[0]
+        row = _rows(result.data)[0]
         row.pop("embedding", None)
         row.pop("fts", None)
         return row
@@ -306,7 +319,7 @@ class SupabaseBackend:
             .eq("profile", profile)
             .execute()
         )
-        return len(result.data) > 0
+        return len(_rows(result.data)) > 0
 
     def update_memory(
         self, memory_id: str, updates: dict[str, Any], profile: str
@@ -321,7 +334,7 @@ class SupabaseBackend:
         )
         if not result.data:
             raise KeyError(f"Memory {memory_id!r} not found in profile {profile!r}")
-        return result.data[0]
+        return _rows(result.data)[0]
 
     def get_profile_ttl(self, profile: str) -> int | None:
         result = (
@@ -333,12 +346,13 @@ class SupabaseBackend:
         )
         if not result.data:
             return None
-        return result.data[0].get("ttl_days")
+        ttl_days = _rows(result.data)[0].get("ttl_days")
+        return ttl_days if isinstance(ttl_days, int) else None
 
     def set_profile_ttl(self, profile: str, ttl_days: int | None) -> dict[str, Any]:
         row = {"profile": profile, "ttl_days": ttl_days}
         result = self._get_client().from_("profile_settings").upsert(row).execute()
-        return result.data[0]
+        return _rows(result.data)[0]
 
     def cleanup_expired(self, profile: str) -> int:
         result = (
@@ -363,20 +377,14 @@ class SupabaseBackend:
         threshold: float = 0.85,
         max_links: int = 5,
     ) -> int:
-        result = (
-            self._get_client()
-            .rpc(
-                "auto_link_memory",
-                {
-                    "new_memory_id": memory_id,
-                    "new_embedding": str(embedding),
-                    "link_threshold": threshold,
-                    "max_links": max_links,
-                    "filter_profile": profile,
-                },
-            )
-            .execute()
-        )
+        params: dict[str, Any] = {
+            "new_memory_id": memory_id,
+            "new_embedding": str(embedding),
+            "link_threshold": threshold,
+            "max_links": max_links,
+            "filter_profile": profile,
+        }
+        result = self._get_client().rpc("auto_link_memory", params).execute()
         return result.data if isinstance(result.data, int) else 0
 
     @with_retry(max_attempts=2, base_delay=0.3)
@@ -387,19 +395,13 @@ class SupabaseBackend:
         max_links: int = 5,
         batch_size: int = 100,
     ) -> int:
-        result = (
-            self._get_client()
-            .rpc(
-                "link_unlinked_memories",
-                {
-                    "filter_profile": profile,
-                    "link_threshold": threshold,
-                    "max_links": max_links,
-                    "batch_size": batch_size,
-                },
-            )
-            .execute()
-        )
+        params: dict[str, Any] = {
+            "filter_profile": profile,
+            "link_threshold": threshold,
+            "max_links": max_links,
+            "batch_size": batch_size,
+        }
+        result = self._get_client().rpc("link_unlinked_memories", params).execute()
         return result.data if isinstance(result.data, int) else 0
 
     @with_retry(max_attempts=2, base_delay=0.3)
@@ -428,7 +430,7 @@ class SupabaseBackend:
             params["filter_source"] = source
 
         result = self._get_client().rpc("explore_memory_graph", params).execute()
-        return result.data
+        return _rows(result.data)
 
     def create_relationship(
         self,
@@ -450,7 +452,7 @@ class SupabaseBackend:
         result = self._get_client().from_("memory_relationships").insert(row).execute()
         if not result.data:
             raise RuntimeError("Insert returned no data for relationship")
-        return result.data[0]
+        return _rows(result.data)[0]
 
     @with_retry(max_attempts=2, base_delay=0.3)
     def get_related_memories(
@@ -471,7 +473,18 @@ class SupabaseBackend:
             params["filter_types"] = relationship_types
 
         result = self._get_client().rpc("get_related_memories", params).execute()
-        return result.data
+        return _rows(result.data)
+
+    def spread_entity_activation(
+        self,
+        entity_tags: list[str],
+        profile: str,
+        max_depth: int = 2,
+        decay: float = 0.65,
+        min_activation: float = 0.05,
+        max_results: int = 50,
+    ) -> list[dict[str, Any]]:
+        return []
 
     def apply_hebbian_decay(self, profile: str, batch_size: int = 1000) -> int:
         return 0
@@ -479,7 +492,7 @@ class SupabaseBackend:
     def count_decay_eligible(self, profile: str) -> int:
         return 0
 
-    def emit_audit_event(self, **kwargs: Any) -> None:
+    def emit_audit_event(self, *args: Any, **kwargs: Any) -> None:
         pass  # Supabase audit: add when RPC function exists
 
     def query_audit_log(
@@ -501,20 +514,14 @@ class SupabaseBackend:
         top_k: int = 3,
         min_similarity: float = 0.0,
     ) -> list[dict[str, Any]]:
-        result = (
-            self._get_client()
-            .rpc(
-                "wiki_topic_search",
-                {
-                    "p_profile": profile,
-                    "p_query_embedding": query_embedding,
-                    "p_top_k": top_k,
-                    "p_min_similarity": min_similarity,
-                },
-            )
-            .execute()
-        )
-        return result.data or []
+        params: dict[str, Any] = {
+            "p_profile": profile,
+            "p_query_embedding": query_embedding,
+            "p_top_k": top_k,
+            "p_min_similarity": min_similarity,
+        }
+        result = self._get_client().rpc("wiki_topic_search", params).execute()
+        return _rows(result.data)
 
     @with_retry(max_attempts=2, base_delay=0.3)
     def wiki_topic_upsert(
@@ -532,7 +539,7 @@ class SupabaseBackend:
     ) -> dict[str, Any]:
         # PostgREST returns bytea as a hex string by default; the migration's
         # function takes bytea. Pass as hex-encoded \x-prefixed string.
-        params = {
+        params: dict[str, Any] = {
             "p_profile": profile,
             "p_topic_key": topic_key,
             "p_content": content,
@@ -547,8 +554,9 @@ class SupabaseBackend:
         result = self._get_client().rpc("wiki_topic_upsert", params).execute()
         # Function returns a single row (RETURNS topic_summaries).
         if isinstance(result.data, list):
-            return result.data[0] if result.data else {}
-        return result.data or {}
+            rows = _rows(result.data)
+            return rows[0] if rows else {}
+        return _row(result.data) if result.data else {}
 
     @with_retry(max_attempts=2, base_delay=0.3)
     def wiki_topic_get_by_key(self, profile: str, topic_key: str) -> dict[str, Any] | None:
@@ -562,58 +570,50 @@ class SupabaseBackend:
         )
         if not result.data:
             return None
-        return result.data[0] if isinstance(result.data, list) else result.data
+        if isinstance(result.data, list):
+            rows = _rows(result.data)
+            return rows[0] if rows else None
+        return _row(result.data)
 
     @with_retry(max_attempts=2, base_delay=0.3)
     def wiki_topic_get_affected(self, memory_id: str) -> list[dict[str, Any]]:
-        result = (
-            self._get_client().rpc("wiki_topic_get_affected", {"p_memory_id": memory_id}).execute()
-        )
-        return result.data or []
+        params: dict[str, Any] = {"p_memory_id": memory_id}
+        result = self._get_client().rpc("wiki_topic_get_affected", params).execute()
+        return _rows(result.data)
 
     @with_retry(max_attempts=2, base_delay=0.3)
     def wiki_topic_mark_stale(self, summary_id: str, reason: str | None = None) -> None:
+        params: dict[str, Any] = {"p_summary_id": summary_id, "p_reason": reason}
         self._get_client().rpc(
             "wiki_topic_mark_stale",
-            {"p_summary_id": summary_id, "p_reason": reason},
+            params,
         ).execute()
 
     @with_retry(max_attempts=2, base_delay=0.3)
     def wiki_topic_sweep_stale(self, profile: str, older_than_days: int = 30) -> int:
-        result = (
-            self._get_client()
-            .rpc(
-                "wiki_topic_sweep_stale",
-                {"p_profile": profile, "p_older_than_days": older_than_days},
-            )
-            .execute()
-        )
-        if isinstance(result.data, list) and result.data:
-            return int(result.data[0]) if not isinstance(result.data[0], dict) else 0
-        return int(result.data) if result.data is not None else 0
+        params: dict[str, Any] = {"p_profile": profile, "p_older_than_days": older_than_days}
+        result = self._get_client().rpc("wiki_topic_sweep_stale", params).execute()
+        data: Any = result.data
+        if isinstance(data, list):
+            if not data:
+                return 0
+            first: Any = data[0]
+            return 0 if isinstance(first, Mapping) else int(first)
+        return int(data) if data is not None else 0
 
     @with_retry(max_attempts=2, base_delay=0.3)
     def wiki_topic_list_stale(
         self, profile: str | None = None, older_than_days: int | None = None
     ) -> list[dict[str, Any]]:
-        result = (
-            self._get_client()
-            .rpc(
-                "wiki_topic_list_stale",
-                {"p_profile": profile, "p_older_than_days": older_than_days},
-            )
-            .execute()
-        )
-        return result.data or []
+        params: dict[str, Any] = {"p_profile": profile, "p_older_than_days": older_than_days}
+        result = self._get_client().rpc("wiki_topic_list_stale", params).execute()
+        return _rows(result.data)
 
     @with_retry(max_attempts=2, base_delay=0.3)
     def wiki_topic_list_fresh_for_drift(self, profile: str) -> list[dict[str, Any]]:
-        result = (
-            self._get_client()
-            .rpc("wiki_topic_list_fresh_for_drift", {"p_profile": profile})
-            .execute()
-        )
-        return result.data or []
+        params: dict[str, Any] = {"p_profile": profile}
+        result = self._get_client().rpc("wiki_topic_list_fresh_for_drift", params).execute()
+        return _rows(result.data)
 
     @with_retry(max_attempts=2, base_delay=0.3)
     def wiki_topic_list_all(self, profile: str) -> list[dict[str, Any]]:
@@ -630,34 +630,29 @@ class SupabaseBackend:
             .order("topic_key")
             .execute()
         )
-        return result.data or []
+        return _rows(result.data)
 
     @with_retry(max_attempts=2, base_delay=0.3)
     def wiki_recompute_get_source_ids(self, profile: str, tag: str) -> list[str]:
-        result = (
-            self._get_client()
-            .rpc(
-                "wiki_recompute_get_source_ids",
-                {"p_profile": profile, "p_tag": tag},
-            )
-            .execute()
-        )
-        rows = result.data or []
-        return [r["id"] if isinstance(r, dict) else r for r in rows]
+        params: dict[str, Any] = {"p_profile": profile, "p_tag": tag}
+        result = self._get_client().rpc("wiki_recompute_get_source_ids", params).execute()
+        data: Any = result.data
+        if not isinstance(data, list):
+            return []
+        ids: list[str] = []
+        for item in data:
+            source_id = item.get("id") if isinstance(item, Mapping) else item
+            if source_id is not None:
+                ids.append(str(source_id))
+        return ids
 
     @with_retry(max_attempts=2, base_delay=0.3)
     def wiki_recompute_get_source_content(self, memory_ids: list[str]) -> list[dict[str, Any]]:
         if not memory_ids:
             return []
-        result = (
-            self._get_client()
-            .rpc(
-                "wiki_recompute_get_source_content",
-                {"p_memory_ids": memory_ids},
-            )
-            .execute()
-        )
-        return result.data or []
+        params: dict[str, Any] = {"p_memory_ids": memory_ids}
+        result = self._get_client().rpc("wiki_recompute_get_source_content", params).execute()
+        return _rows(result.data)
 
     @with_retry(max_attempts=2, base_delay=0.3)
     def wiki_walk_graph(
@@ -669,22 +664,16 @@ class SupabaseBackend:
         relationship_types: list[str] | None = None,
         result_limit: int = 50,
     ) -> list[dict[str, Any]]:
-        result = (
-            self._get_client()
-            .rpc(
-                "wiki_walk_graph",
-                {
-                    "p_start_id": start_id,
-                    "p_max_depth": max_depth,
-                    "p_direction": direction,
-                    "p_min_strength": min_strength,
-                    "p_relationship_types": relationship_types,
-                    "p_result_limit": result_limit,
-                },
-            )
-            .execute()
-        )
-        return result.data or []
+        params: dict[str, Any] = {
+            "p_start_id": start_id,
+            "p_max_depth": max_depth,
+            "p_direction": direction,
+            "p_min_strength": min_strength,
+            "p_relationship_types": relationship_types,
+            "p_result_limit": result_limit,
+        }
+        result = self._get_client().rpc("wiki_walk_graph", params).execute()
+        return _rows(result.data)
 
     def _split_count_sample(self, rows: list[dict[str, Any]]) -> tuple[int, list[dict[str, Any]]]:
         """Lint RPCs return total_count column on every row; split it out."""
@@ -696,34 +685,22 @@ class SupabaseBackend:
 
     @with_retry(max_attempts=2, base_delay=0.3)
     def wiki_lint_contradictions(self, profile: str, sample_size: int = 10) -> dict[str, Any]:
-        result = (
-            self._get_client()
-            .rpc(
-                "wiki_lint_contradictions",
-                {"p_profile": profile, "p_sample_size": sample_size},
-            )
-            .execute()
-        )
-        count, sample = self._split_count_sample(result.data or [])
+        params: dict[str, Any] = {"p_profile": profile, "p_sample_size": sample_size}
+        result = self._get_client().rpc("wiki_lint_contradictions", params).execute()
+        count, sample = self._split_count_sample(_rows(result.data))
         return {"count": count, "sample": sample}
 
     @with_retry(max_attempts=2, base_delay=0.3)
     def wiki_lint_orphans(
         self, profile: str, sample_size: int = 10, grace_minutes: int = 5
     ) -> dict[str, Any]:
-        result = (
-            self._get_client()
-            .rpc(
-                "wiki_lint_orphans",
-                {
-                    "p_profile": profile,
-                    "p_sample_size": sample_size,
-                    "p_grace_minutes": grace_minutes,
-                },
-            )
-            .execute()
-        )
-        count, sample = self._split_count_sample(result.data or [])
+        params: dict[str, Any] = {
+            "p_profile": profile,
+            "p_sample_size": sample_size,
+            "p_grace_minutes": grace_minutes,
+        }
+        result = self._get_client().rpc("wiki_lint_orphans", params).execute()
+        count, sample = self._split_count_sample(_rows(result.data))
         return {"count": count, "sample": sample}
 
     @with_retry(max_attempts=2, base_delay=0.3)
@@ -733,17 +710,11 @@ class SupabaseBackend:
         older_than_days: int = 90,
         sample_size: int = 10,
     ) -> dict[str, Any]:
-        result = (
-            self._get_client()
-            .rpc(
-                "wiki_lint_stale_lifecycle",
-                {
-                    "p_profile": profile,
-                    "p_older_than_days": older_than_days,
-                    "p_sample_size": sample_size,
-                },
-            )
-            .execute()
-        )
-        count, sample = self._split_count_sample(result.data or [])
+        params: dict[str, Any] = {
+            "p_profile": profile,
+            "p_older_than_days": older_than_days,
+            "p_sample_size": sample_size,
+        }
+        result = self._get_client().rpc("wiki_lint_stale_lifecycle", params).execute()
+        count, sample = self._split_count_sample(_rows(result.data))
         return {"count": count, "sample": sample, "older_than_days": older_than_days}

--- a/src/ogham/cli.py
+++ b/src/ogham/cli.py
@@ -643,11 +643,10 @@ def dashboard(
     # from env / config.env, which is surprising and broke the Go CLI's
     # profile handoff -- see
     # docs/plans/2026-04-16-go-cli-enterprise.md for the diagnosis.
-    if not profile:
-        profile = settings.default_profile
+    active_profile = profile or settings.default_profile
 
-    dashboard_app = create_app(profile=profile)
-    console.print(f"[green]Ogham dashboard ({profile}) → http://{host}:{port}[/green]")
+    dashboard_app = create_app(profile=active_profile)
+    console.print(f"[green]Ogham dashboard ({active_profile}) → http://{host}:{port}[/green]")
     uvicorn.run(dashboard_app, host=host, port=port, log_level="warning")
 
 

--- a/src/ogham/database.py
+++ b/src/ogham/database.py
@@ -7,11 +7,13 @@ based on ``settings.database_backend`` (defaults to ``"supabase"``).
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
+
+from ogham.backends.protocol import DatabaseBackend
 
 logger = logging.getLogger(__name__)
 
-_backend = None
+_backend: DatabaseBackend | None = None
 
 
 def set_tenant_context(tenant_id: str | None) -> None:
@@ -45,7 +47,7 @@ def _reset_backend() -> None:
     _backend = None
 
 
-def get_backend():
+def get_backend() -> DatabaseBackend:
     """Return (and lazily create) the singleton backend instance."""
     global _backend
     if _backend is None:
@@ -75,7 +77,7 @@ def get_client():
     backend = get_backend()
     if not hasattr(backend, "_get_client"):
         raise RuntimeError(f"Backend {type(backend).__name__!r} does not expose a raw client")
-    return backend._get_client()
+    return cast(Any, backend)._get_client()
 
 
 # ── Thin delegates — one per public function ────────────────────────────
@@ -257,7 +259,8 @@ def count_decay_eligible(profile: str) -> int:
 
 
 def emit_audit_event(**kwargs: Any) -> None:
-    get_backend().emit_audit_event(**kwargs)
+    backend = cast(Any, get_backend())
+    backend.emit_audit_event(**kwargs)
 
 
 def query_audit_log(
@@ -274,8 +277,17 @@ def spread_entity_activation(
     min_activation: float = 0.05,
     max_results: int = 50,
 ) -> list[dict[str, Any]]:
-    return get_backend().spread_entity_activation(
-        entity_tags, profile, max_depth, decay, min_activation, max_results
+    backend = cast(Any, get_backend())
+    return cast(
+        list[dict[str, Any]],
+        backend.spread_entity_activation(
+            entity_tags,
+            profile,
+            max_depth,
+            decay,
+            min_activation,
+            max_results,
+        ),
     )
 
 
@@ -365,11 +377,15 @@ def walk_memory_graph(
     if depth > 5:
         raise ValueError("depth must be <= 5; use explore_knowledge for broader walks")
 
-    return get_backend().wiki_walk_graph(
-        start_id=start_id,
-        max_depth=depth,
-        direction=direction,
-        min_strength=min_strength,
-        relationship_types=relationship_types,
-        result_limit=limit,
+    backend = cast(Any, get_backend())
+    return cast(
+        list[dict[str, Any]],
+        backend.wiki_walk_graph(
+            start_id=start_id,
+            max_depth=depth,
+            direction=direction,
+            min_strength=min_strength,
+            relationship_types=relationship_types,
+            result_limit=limit,
+        ),
     )

--- a/src/ogham/embeddings.py
+++ b/src/ogham/embeddings.py
@@ -11,7 +11,8 @@ such as `model`, `input_tokens`, and `cache_hit`.
 import hashlib
 import logging
 import math
-from typing import TypedDict
+from collections.abc import Callable
+from typing import Any, cast
 
 from ogham.config import settings
 from ogham.embedding_cache import EmbeddingCache
@@ -33,12 +34,7 @@ def _get_cache() -> EmbeddingCache:
     return _cache
 
 
-class EmbeddingUsage(TypedDict, total=False):
-    """Best-effort provider usage captured alongside an embedding request."""
-
-    model: str
-    input_tokens: int
-    cache_hit: bool
+EmbeddingUsage = dict[str, Any]
 
 
 def get_cache_stats() -> dict:
@@ -326,7 +322,7 @@ _gemini_client = None
 def _get_gemini_client():
     global _gemini_client
     if _gemini_client is None:
-        from google import genai
+        from google import genai  # pyright: ignore[reportAttributeAccessIssue]
 
         _gemini_client = genai.Client(api_key=settings.gemini_api_key)
     return _gemini_client
@@ -388,7 +384,7 @@ def _l2_normalize(embedding: list[float]) -> list[float]:
 def generate_embeddings_batch(
     texts: list[str],
     batch_size: int | None = None,
-    on_progress: callable = None,
+    on_progress: Callable[[int, int], None] | None = None,
     usage_out: EmbeddingUsage | None = None,
 ) -> list[list[float]]:
     """Generate embeddings for multiple texts, batched for efficiency.
@@ -402,8 +398,9 @@ def generate_embeddings_batch(
         usage_out: Optional dict mutated in place with aggregated usage for
             uncached provider calls only. Cache-hit items contribute zero spend.
     """
-    if batch_size is None:
-        batch_size = settings.embedding_batch_size
+    effective_batch_size = (
+        batch_size if batch_size is not None else settings.embedding_batch_size or 32
+    )
     total = len(texts)
     results: list[list[float] | None] = [None] * total
     uncached: list[tuple[int, str, str]] = []  # (index, cache_key, text)
@@ -423,8 +420,8 @@ def generate_embeddings_batch(
         on_progress(embedded, total)
 
     # Batch embed uncached texts
-    for start in range(0, len(uncached), batch_size):
-        batch = uncached[start : start + batch_size]
+    for start in range(0, len(uncached), effective_batch_size):
+        batch = uncached[start : start + effective_batch_size]
         batch_texts = [t for _, _, t in batch]
         batch_usage: EmbeddingUsage = {}
         if usage_out is None:
@@ -440,7 +437,9 @@ def generate_embeddings_batch(
             on_progress(embedded, total)
 
     _set_usage_out(usage_out, total_usage)
-    return results
+    if any(result is None for result in results):
+        raise RuntimeError("Embedding batch completed with missing results")
+    return cast(list[list[float]], results)
 
 
 @with_retry(max_attempts=3, base_delay=0.5, exceptions=(ConnectionError, OSError))

--- a/src/ogham/graph.py
+++ b/src/ogham/graph.py
@@ -25,11 +25,22 @@ parallel arrays), replacing the previous C(n, 2) per-pair ON CONFLICT loop.
 from __future__ import annotations
 
 from itertools import combinations
+from typing import Any, Protocol, cast
 
 from ogham.database import get_backend
 
 HEBBIAN_RATE = 0.01
 BOOTSTRAP_STRENGTH = 0.1
+
+
+class _SqlExecutor(Protocol):
+    def _execute(
+        self,
+        query: str,
+        params: dict[str, Any] | None = None,
+        *,
+        fetch: str = "all",
+    ) -> Any: ...
 
 
 def strengthen_edges(memory_ids: list[str]) -> int:
@@ -49,7 +60,7 @@ def strengthen_edges(memory_ids: list[str]) -> int:
     sources = [p[0] for p in pairs]
     targets = [p[1] for p in pairs]
 
-    backend = get_backend()
+    backend = cast(_SqlExecutor, get_backend())
     result = backend._execute(
         """INSERT INTO memory_relationships
                (source_id, target_id, relationship, strength, created_by)

--- a/src/ogham/health.py
+++ b/src/ogham/health.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any, cast
 
 from ogham.config import settings
 from ogham.database import get_backend
@@ -9,7 +10,7 @@ logger = logging.getLogger(__name__)
 def check_database() -> dict[str, str | bool]:
     """Check database connectivity with a lightweight query."""
     try:
-        backend = get_backend()
+        backend = cast(Any, get_backend())
         if hasattr(backend, "_get_client"):
             # Supabase backend
             client = backend._get_client()
@@ -109,7 +110,7 @@ def check_embedding_provider() -> dict[str, str | bool]:
 
     elif provider == "gemini":
         try:
-            from google import genai  # noqa: F401
+            from google import genai  # pyright: ignore[reportAttributeAccessIssue]  # noqa: F401
         except ImportError:
             return {
                 "status": "error",

--- a/src/ogham/hooks.py
+++ b/src/ogham/hooks.py
@@ -13,6 +13,7 @@ import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 # Lifecycle: advance_stages is scheduled to run off the hot path when a
 # session starts. Imports hoisted to module top so tests can patch
@@ -57,10 +58,10 @@ _ALWAYS_SKIP_TOOLS = frozenset(
 )
 
 # --- Config loading ---
-_config_cache: dict | None = None
+_config_cache: dict[str, Any] | None = None
 
 
-def _load_config() -> dict:
+def _load_config() -> dict[str, Any]:
     """Load hooks config from YAML file, with caching.
 
     Looks for hooks_config.yaml next to this module, then falls back
@@ -76,7 +77,8 @@ def _load_config() -> dict:
             import yaml
 
             with open(config_path) as f:
-                _config_cache = yaml.safe_load(f)
+                loaded = yaml.safe_load(f)
+                _config_cache = loaded if isinstance(loaded, dict) else {}
                 logger.debug("Loaded hooks config from %s", config_path)
                 return _config_cache
         except ImportError:
@@ -441,7 +443,19 @@ def _mask_secrets(text: str) -> str:
     return masked
 
 
-def session_start(cwd: str, profile: str = "work", limit: int = 8) -> str:
+def _type_tags(memory: dict[str, Any]) -> list[str]:
+    """Return display-safe type tags from a memory row."""
+    raw_tags = memory.get("tags", [])
+    if not isinstance(raw_tags, list):
+        return []
+    return [tag for tag in raw_tags if isinstance(tag, str) and tag.startswith("type:")]
+
+
+def session_start(
+    cwd: str,
+    profile: str = "work",
+    limit: int = 8,
+) -> str:
     """Return markdown context for session injection.
 
     Searches for memories relevant to the current working directory and
@@ -491,8 +505,8 @@ def session_start(cwd: str, profile: str = "work", limit: int = 8) -> str:
 
     lines = ["## Session Context", ""]
     for r in results:
-        content = r.get("content", "")[:200]
-        tags = [t for t in r.get("tags", []) if t.startswith("type:")]
+        content = str(r.get("content", ""))[:200]
+        tags = _type_tags(r)
         tag_str = f" ({', '.join(tags)})" if tags else ""
         lines.append(f"- {content}{tag_str}")
 
@@ -501,12 +515,12 @@ def session_start(cwd: str, profile: str = "work", limit: int = 8) -> str:
     return "\n".join(lines)
 
 
-def post_tool(hook_input: dict, profile: str = "work") -> None:
+def post_tool(hook_input: dict[str, Any], profile: str = "work") -> None:
     """Capture a tool execution as a memory.
 
     Skips Ogham's own tools to prevent infinite loops.
     """
-    tool_name = hook_input.get("tool_name", "")
+    tool_name = str(hook_input.get("tool_name", ""))
 
     # Skip Ogham's own tools (infinite loop prevention)
     if any(tool_name.startswith(p) for p in _SKIP_PREFIXES):
@@ -517,8 +531,8 @@ def post_tool(hook_input: dict, profile: str = "work") -> None:
         return
 
     tool_input = hook_input.get("tool_input", {})
-    cwd = hook_input.get("cwd", "")
-    session_id = hook_input.get("session_id", "")
+    cwd = str(hook_input.get("cwd", ""))
+    session_id = str(hook_input.get("session_id", ""))
 
     # Extract summary from tool input
     summary = ""
@@ -590,7 +604,11 @@ def post_tool(hook_input: dict, profile: str = "work") -> None:
         logger.debug("post_tool: store failed, ignoring")
 
 
-def pre_compact(session_id: str, cwd: str, profile: str = "work") -> None:
+def pre_compact(
+    session_id: str,
+    cwd: str,
+    profile: str = "work",
+) -> None:
     """Drain session context to Ogham before compaction."""
     project_name = os.path.basename(cwd)
     timestamp = datetime.now(timezone.utc).isoformat()
@@ -616,7 +634,11 @@ def pre_compact(session_id: str, cwd: str, profile: str = "work") -> None:
         logger.debug("pre_compact: store failed, ignoring")
 
 
-def post_compact(cwd: str, profile: str = "work", limit: int = 10) -> str:
+def post_compact(
+    cwd: str,
+    profile: str = "work",
+    limit: int = 10,
+) -> str:
     """Rehydrate context after compaction.
 
     Returns markdown with the most relevant memories for the project.
@@ -644,8 +666,8 @@ def post_compact(cwd: str, profile: str = "work", limit: int = 10) -> str:
 
     lines = ["## Restored Context", ""]
     for r in results:
-        content = r.get("content", "")[:300]
-        tags = [t for t in r.get("tags", []) if t.startswith("type:")]
+        content = str(r.get("content", ""))[:300]
+        tags = _type_tags(r)
         tag_str = f" ({', '.join(tags)})" if tags else ""
         lines.append(f"- {content}{tag_str}")
 

--- a/src/ogham/init_wizard.py
+++ b/src/ogham/init_wizard.py
@@ -15,6 +15,7 @@ import platform
 import shutil
 from importlib.metadata import version as pkg_version
 from pathlib import Path
+from typing import Any, cast
 
 from rich.console import Console
 from rich.panel import Panel
@@ -176,8 +177,8 @@ def _prompt_database() -> dict:
             "   Supabase secret key (formerly service_role)",
             default=default_key or None,
         )
-        env_vars["SUPABASE_URL"] = url
-        env_vars["SUPABASE_KEY"] = key
+        env_vars["SUPABASE_URL"] = url or ""
+        env_vars["SUPABASE_KEY"] = key or ""
     else:
         console.print("\n   Great. Paste your PostgreSQL connection string.")
         console.print("   [cyan]Neon: Dashboard -> Connection Details -> Connection string[/cyan]")
@@ -190,7 +191,7 @@ def _prompt_database() -> dict:
         if default_url:
             console.print("   [cyan]Found DATABASE_URL in environment.[/cyan]")
         url = Prompt.ask("   Database URL", default=default_url or None)
-        env_vars["DATABASE_URL"] = url
+        env_vars["DATABASE_URL"] = url or ""
 
     return env_vars
 
@@ -242,25 +243,25 @@ def _prompt_embeddings() -> dict:
         if default_key:
             console.print("   [cyan]Found OPENAI_API_KEY in environment.[/cyan]")
         key = Prompt.ask("   OpenAI API key", default=default_key or None)
-        env_vars["OPENAI_API_KEY"] = key
+        env_vars["OPENAI_API_KEY"] = key or ""
     elif provider == "gemini":
         default_key = os.environ.get("GEMINI_API_KEY", "")
         if default_key:
             console.print("   [cyan]Found GEMINI_API_KEY in environment.[/cyan]")
         key = Prompt.ask("   Gemini API key", default=default_key or None)
-        env_vars["GEMINI_API_KEY"] = key
+        env_vars["GEMINI_API_KEY"] = key or ""
     elif provider == "voyage":
         default_key = os.environ.get("VOYAGE_API_KEY", "")
         if default_key:
             console.print("   [cyan]Found VOYAGE_API_KEY in environment.[/cyan]")
         key = Prompt.ask("   Voyage AI API key", default=default_key or None)
-        env_vars["VOYAGE_API_KEY"] = key
+        env_vars["VOYAGE_API_KEY"] = key or ""
     elif provider == "mistral":
         default_key = os.environ.get("MISTRAL_API_KEY", "")
         if default_key:
             console.print("   [cyan]Found MISTRAL_API_KEY in environment.[/cyan]")
         key = Prompt.ask("   Mistral API key", default=default_key or None)
-        env_vars["MISTRAL_API_KEY"] = key
+        env_vars["MISTRAL_API_KEY"] = key or ""
     elif provider == "ollama":
         default_url = os.environ.get("OLLAMA_URL", "http://localhost:11434")
         url = Prompt.ask("   Ollama URL", default=default_url)
@@ -449,7 +450,7 @@ def _run_schema(env_vars: dict) -> bool:
             with console.status("   Running schema migration..."):
                 conn = psycopg.connect(db_url)
                 conn.autocommit = True
-                conn.execute(schema_sql)
+                cast(Any, conn).execute(schema_sql)
                 conn.close()
             console.print("   [green]Schema migration complete.[/green]")
             return True
@@ -601,6 +602,7 @@ def _configure_clients(
 def _test_connection(env_vars: dict) -> bool:
     """Validate database and embedding connectivity."""
     console.print("\n[bold]6. Let's check everything works[/bold]")
+    settings_obj: Any | None = None
 
     # Temporarily set env vars for the health check
     original_env = {}
@@ -612,7 +614,8 @@ def _test_connection(env_vars: dict) -> bool:
         # Force fresh settings instance from the temp env vars
         from ogham.config import settings
 
-        settings._force()
+        settings_obj = settings
+        settings_obj._force()
 
         # Check database
         with console.status("   Checking database..."):
@@ -651,7 +654,8 @@ def _test_connection(env_vars: dict) -> bool:
                 os.environ.pop(key, None)
             else:
                 os.environ[key] = original
-        settings._reset()
+        if settings_obj is not None:
+            settings_obj._reset()
 
 
 # ---------------------------------------------------------------------------

--- a/src/ogham/lifecycle.py
+++ b/src/ogham/lifecycle.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from typing import Any, Protocol, cast
 
 from ogham.database import get_backend
 
@@ -25,6 +26,16 @@ DEFAULT_DWELL_HOURS = 1.0
 DEFAULT_SURPRISE_GATE = 0.3
 DEFAULT_IMPORTANCE_GATE = 0.5
 DEFAULT_EDITING_WINDOW_MINUTES = 30
+
+
+class _SqlExecutor(Protocol):
+    def _execute(
+        self,
+        query: str,
+        params: dict[str, Any] | None = None,
+        *,
+        fetch: str = "all",
+    ) -> Any: ...
 
 
 @dataclass
@@ -45,7 +56,7 @@ def advance_stages(profile: str) -> StageReport:
     HNSW index on memories is not disturbed. The gates still come from
     memories, via a PK join -- see migration 026 for the rationale.
     """
-    backend = get_backend()
+    backend = cast(_SqlExecutor, get_backend())
     report = StageReport()
 
     cutoff = datetime.now(tz=timezone.utc) - timedelta(hours=DEFAULT_DWELL_HOURS)
@@ -76,7 +87,7 @@ def advance_stages(profile: str) -> StageReport:
 
 def close_editing_windows(profile: str) -> int:
     """Close EDITING windows older than DEFAULT_EDITING_WINDOW_MINUTES."""
-    backend = get_backend()
+    backend = cast(_SqlExecutor, get_backend())
     cutoff = datetime.now(tz=timezone.utc) - timedelta(minutes=DEFAULT_EDITING_WINDOW_MINUTES)
     result = backend._execute(
         """UPDATE memory_lifecycle
@@ -103,7 +114,7 @@ def open_editing_window(memory_ids: list[str]) -> None:
     """
     if not memory_ids:
         return
-    backend = get_backend()
+    backend = cast(_SqlExecutor, get_backend())
     backend._execute(
         """UPDATE memory_lifecycle
               SET stage = 'editing',
@@ -118,7 +129,7 @@ def open_editing_window(memory_ids: list[str]) -> None:
 
 def lifecycle_pipeline_counts(profile: str) -> dict[str, int]:
     """Return {stage: count} for the dashboard pipeline card."""
-    backend = get_backend()
+    backend = cast(_SqlExecutor, get_backend())
     rows = backend._execute(
         """SELECT stage, count(*) AS n
              FROM memory_lifecycle

--- a/src/ogham/onnx_embedder.py
+++ b/src/ogham/onnx_embedder.py
@@ -13,6 +13,7 @@ import logging
 import threading
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, cast
 
 logger = logging.getLogger(__name__)
 
@@ -33,8 +34,8 @@ class OnnxResult:
 
 # ── Singleton model holder ────────────────────────────────────────────
 
-_tokenizer = None
-_session = None
+_tokenizer: Any | None = None
+_session: Any | None = None
 _model_lock = threading.Lock()
 
 
@@ -42,11 +43,15 @@ def _get_model(model_path: str | None = None):
     """Lazy-load the ONNX session and tokenizer (singleton, thread-safe)."""
     global _tokenizer, _session
     if _session is not None:
+        if _tokenizer is None:
+            raise RuntimeError("ONNX session loaded without tokenizer")
         return _tokenizer, _session
 
     with _model_lock:
         # Double-check after acquiring lock
         if _session is not None:
+            if _tokenizer is None:
+                raise RuntimeError("ONNX session loaded without tokenizer")
             return _tokenizer, _session
 
         if model_path is None:
@@ -62,9 +67,10 @@ def _get_model(model_path: str | None = None):
         from tokenizers import Tokenizer
 
         logger.info("Loading tokenizer for BAAI/bge-m3...")
-        _tokenizer = Tokenizer.from_pretrained("BAAI/bge-m3")
-        _tokenizer.enable_truncation(max_length=8192)
-        _tokenizer.no_padding()
+        tokenizer = cast(Any, Tokenizer.from_pretrained("BAAI/bge-m3"))
+        tokenizer.enable_truncation(max_length=8192)
+        tokenizer.no_padding()
+        _tokenizer = tokenizer
 
         logger.info("Loading ONNX model from %s...", model_path)
         options = ort.SessionOptions()
@@ -73,13 +79,17 @@ def _get_model(model_path: str | None = None):
         options.log_severity_level = 2  # WARNING
         options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_BASIC
 
-        _session = ort.InferenceSession(
-            model_path,
-            sess_options=options,
-            providers=["CPUExecutionProvider"],
+        session = cast(
+            Any,
+            ort.InferenceSession(
+                model_path,
+                sess_options=options,
+                providers=["CPUExecutionProvider"],
+            ),
         )
+        _session = session
         logger.info("ONNX BGE-M3 model loaded.")
-        return _tokenizer, _session
+        return tokenizer, session
 
 
 # ── Encoding ──────────────────────────────────────────────────────────

--- a/src/ogham/retry.py
+++ b/src/ogham/retry.py
@@ -1,11 +1,13 @@
 import functools
 import logging
 import time
+from collections.abc import Callable
+from typing import TypeVar, cast
 
 logger = logging.getLogger(__name__)
 
 # Build retryable exception tuple — include psycopg if installed
-_RETRYABLE: tuple = (ConnectionError, TimeoutError, OSError)
+_RETRYABLE: tuple[type[BaseException], ...] = (ConnectionError, TimeoutError, OSError)
 try:
     import psycopg
 
@@ -17,7 +19,7 @@ except ImportError:
 def with_retry(
     max_attempts: int = 3,
     base_delay: float = 0.5,
-    exceptions: tuple = _RETRYABLE,
+    exceptions: tuple[type[BaseException], ...] = _RETRYABLE,
 ):
     """Retry decorator with exponential backoff.
 
@@ -27,10 +29,12 @@ def with_retry(
         exceptions: Exception types to retry on
     """
 
-    def decorator(fn):
+    F = TypeVar("F", bound=Callable[..., object])
+
+    def decorator(fn: F) -> F:
         @functools.wraps(fn)
         def wrapper(*args, **kwargs):
-            last_exception = None
+            last_exception: BaseException | None = None
             for attempt in range(1, max_attempts + 1):
                 try:
                     return fn(*args, **kwargs)
@@ -57,8 +61,8 @@ def with_retry(
                     time.sleep(delay)
 
             # Should never reach here, but satisfy type checker
-            raise last_exception
+            raise RuntimeError("retry loop exited without returning") from last_exception
 
-        return wrapper
+        return cast(F, wrapper)
 
     return decorator

--- a/src/ogham/service.py
+++ b/src/ogham/service.py
@@ -12,7 +12,7 @@ import os
 import re
 from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Any, cast
 
 from ogham.data.loader import get_direction_words
 from ogham.database import auto_link_memory as db_auto_link
@@ -191,7 +191,7 @@ def store_memory_enriched(
     metadata["original_importance"] = importance
 
     # Generate embedding (skip if pre-computed, e.g. from gateway cache)
-    embedding_usage = None
+    embedding_usage: EmbeddingUsage | None = None
     if embedding is None:
         embedding_usage = {}
         embedding = generate_embedding(content, usage_out=embedding_usage)
@@ -390,7 +390,7 @@ def _read_time_extract(query: str, results: list[dict[str, Any]]) -> list[dict[s
             )
             facts = response.choices[0].message.content or ""
         else:
-            from google import genai
+            from google import genai  # pyright: ignore[reportAttributeAccessIssue]
 
             api_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
             client = genai.Client(api_key=api_key)
@@ -984,7 +984,7 @@ def _exact_content_search(anchor: str, profile: str, limit: int) -> list[dict[st
     """
     from ogham.database import get_backend
 
-    backend = get_backend()
+    backend = cast(Any, get_backend())
 
     # Extract the most specific word from the anchor (longest, likely a name)
     words = [w for w in anchor.split() if len(w) > 2]
@@ -1025,7 +1025,7 @@ def _exact_content_search(anchor: str, profile: str, limit: int) -> list[dict[st
                 .limit(limit)
                 .execute()
             )
-            return result.data if result.data else []
+            return cast(list[dict[str, Any]], result.data) if result.data else []
     except Exception as e:
         logger.debug("Exact content search failed for '%s': %s", search_term, e)
 
@@ -1733,7 +1733,7 @@ def _profile_graph_density(profile: str) -> float:
     try:
         from ogham.database import get_backend
 
-        backend = get_backend()
+        backend = cast(Any, get_backend())
         rows = backend._execute(
             """SELECT
                  count(distinct entity_id)::float as entities,

--- a/src/ogham/tools/memory.py
+++ b/src/ogham/tools/memory.py
@@ -4,7 +4,7 @@ import logging
 import re
 import time
 from datetime import datetime, timezone
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 
 from fastmcp import Context
 from pydantic import BeforeValidator
@@ -984,7 +984,7 @@ def suggest_connections(
     """
     from ogham.database import get_backend
 
-    backend = get_backend()
+    backend = cast(Any, get_backend())
     try:
         rows = backend._execute(
             """
@@ -1075,11 +1075,7 @@ def compress_old_memories() -> dict[str, Any]:
 
         if target == 1 and current == 0:
             gist = compress_to_gist(content)
-            db_update(
-                mem["id"],
-                content=gist,
-                profile=active_profile,
-            )
+            db_update(mem["id"], {"content": gist}, profile=active_profile)
             # Store original and update compression level via direct update
             _update_compression(mem["id"], compression_level=1, original_content=content)
             stats["compressed_to_gist"] += 1
@@ -1089,11 +1085,7 @@ def compress_old_memories() -> dict[str, Any]:
                 # Save original before any compression
                 _update_compression(mem["id"], original_content=content)
             tag_repr = compress_to_tags(content, tags)
-            db_update(
-                mem["id"],
-                content=tag_repr,
-                profile=active_profile,
-            )
+            db_update(mem["id"], {"content": tag_repr}, profile=active_profile)
             _update_compression(mem["id"], compression_level=2)
             stats["compressed_to_tags"] += 1
 
@@ -1108,7 +1100,7 @@ def _update_compression(
     """Update compression columns directly via backend."""
     from ogham.database import get_backend
 
-    backend = get_backend()
+    backend = cast(Any, get_backend())
     updates = {}
     if compression_level is not None:
         updates["compression_level"] = compression_level

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 
@@ -27,13 +28,27 @@ def _destructive_db_safe() -> tuple[bool, str]:
 
 
 @pytest.fixture(autouse=True)
-def _reset_db_backend():
-    """Reset the database backend singleton between tests."""
+def _isolated_unit_environment(monkeypatch, request):
+    """Keep unit tests independent from a developer's local Ogham env."""
+    is_external_integration = request.node.get_closest_marker(
+        "integration"
+    ) or request.node.get_closest_marker("postgres_integration")
+
+    if not is_external_integration:
+        monkeypatch.setenv("DATABASE_BACKEND", "supabase")
+        monkeypatch.setenv("SUPABASE_URL", "https://fake.supabase.co")
+        monkeypatch.setenv("SUPABASE_KEY", "fake-key")
+        monkeypatch.setenv("EMBEDDING_PROVIDER", "ollama")
+        monkeypatch.setenv("DEFAULT_PROFILE", "default")
+
+    from ogham.config import settings
     from ogham.database import _reset_backend
 
+    settings._reset()
     _reset_backend()
     yield
     _reset_backend()
+    settings._reset()
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -79,7 +94,7 @@ def _apply_lifecycle_migrations():
             "SELECT column_name FROM information_schema.columns WHERE table_name = 'memories'",
             fetch="all",
         )
-        col_names = {r[0] if isinstance(r, tuple) else r["column_name"] for r in cols}
+        col_names = {str(r["column_name"]) for r in cols}
         if "stage" not in col_names:
             mig_025 = (
                 Path(__file__).parent.parent / "src/ogham/sql/migrations/025_memory_lifecycle.sql"
@@ -138,7 +153,7 @@ def pg_test_profile():
     from ogham.database import get_backend
 
     profile = "test-lifecycle-parity"
-    backend = get_backend()
+    backend = cast(Any, get_backend())
 
     def _table_exists(name):
         rows = backend._execute(
@@ -155,7 +170,7 @@ def pg_test_profile():
             {"t": table},
             fetch="all",
         )
-        return {r[0] if isinstance(r, tuple) else r["column_name"] for r in rows}
+        return {str(r["column_name"]) for r in rows}
 
     # If memory_lifecycle isn't there yet, apply 025 (if needed) then 026.
     if not _table_exists("memory_lifecycle"):
@@ -201,7 +216,7 @@ def pg_fresh_db():
 
     from ogham.database import get_backend
 
-    backend = get_backend()
+    backend = cast(Any, get_backend())
     profile = "test-025"
 
     class _Harness:
@@ -232,14 +247,14 @@ def pg_fresh_db():
                 {"t": table},
                 fetch="all",
             )
-            return [r[0] if isinstance(r, tuple) else r["column_name"] for r in rows]
+            return [str(r["column_name"]) for r in rows]
 
         def tables(self):
             rows = self.be._execute(
                 "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'",
                 fetch="all",
             )
-            return [r[0] if isinstance(r, tuple) else r["table_name"] for r in rows]
+            return [str(r["table_name"]) for r in rows]
 
     def _cleanup():
         # Row-level cleanup for test-025 profile (shared by 025 + 026 tests).

--- a/tests/test_audit_embedding_usage.py
+++ b/tests/test_audit_embedding_usage.py
@@ -126,11 +126,15 @@ def test_store_memory_audit_includes_embedding_usage():
         patch(
             "ogham.service.generate_embedding",
             side_effect=lambda text, usage_out=None: (
-                usage_out.update({"model": "openai:text-embedding-3-small", "input_tokens": 250})
-                if usage_out is not None
-                else None
-            )
-            or FAKE_EMBEDDING,
+                (
+                    usage_out.update(
+                        {"model": "openai:text-embedding-3-small", "input_tokens": 250}
+                    )
+                    if usage_out is not None
+                    else None
+                )
+                or FAKE_EMBEDDING
+            ),
         ),
         patch("ogham.service.hybrid_search_memories", return_value=[]),
         patch("ogham.service.db_get_profile_ttl", return_value=None),
@@ -205,9 +209,9 @@ def test_search_audit_accumulates_full_embedding_usage():
         patch(
             "ogham.service.generate_embedding",
             side_effect=lambda text, usage_out=None: (
-                usage_out.update(usage_calls.pop(0)[1]) if usage_out is not None else None
-            )
-            or FAKE_EMBEDDING,
+                (usage_out.update(usage_calls.pop(0)[1]) if usage_out is not None else None)
+                or FAKE_EMBEDDING
+            ),
         ),
         patch("ogham.service.is_ordering_query", return_value=False),
         patch("ogham.service.is_multi_hop_temporal", return_value=True),

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -89,7 +89,7 @@ def test_post_tool_skips_ogham_tools():
                 {"tool_name": tool_name, "tool_input": {"query": "test"}},
                 profile="work",
             )
-        mock_store.assert_not_called(), f"{tool_name} should be skipped"
+        assert mock_store.call_count == 0, f"{tool_name} should be skipped"
 
 
 def test_post_tool_skips_always_skip_tools():
@@ -117,7 +117,7 @@ def test_post_tool_skips_always_skip_tools():
                 },
                 profile="work",
             )
-        mock_store.assert_not_called(), f"{tool_name} should be always-skipped"
+        assert mock_store.call_count == 0, f"{tool_name} should be always-skipped"
 
 
 def test_post_tool_skips_edit_write_tools():
@@ -135,7 +135,7 @@ def test_post_tool_skips_edit_write_tools():
                 },
                 profile="work",
             )
-        mock_store.assert_not_called(), f"{tool_name} should be skipped"
+        assert mock_store.call_count == 0, f"{tool_name} should be skipped"
 
 
 def test_post_tool_skips_noise_bash():
@@ -153,7 +153,7 @@ def test_post_tool_skips_noise_bash():
                 },
                 profile="work",
             )
-        mock_store.assert_not_called(), f"'{cmd}' should be skipped as noise"
+        assert mock_store.call_count == 0, f"'{cmd}' should be skipped as noise"
 
 
 def test_post_tool_captures_signal_bash():

--- a/tests/test_hooks_enqueue.py
+++ b/tests/test_hooks_enqueue.py
@@ -7,6 +7,7 @@ patched so we can assert enqueue calls without running LLM / embedding.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
@@ -101,7 +102,8 @@ def test_delete_memory_enqueues_pre_delete_tags(_hooks_env):
 
     # Seed directly so we don't chain through store_memory (which would
     # also enqueue and confuse the test).
-    row = get_backend()._execute(
+    backend = cast(Any, get_backend())
+    row = backend._execute(
         """INSERT INTO memories (content, profile, source, tags)
            VALUES ('body to delete', 'test-025', 't', ARRAY['alpha', 'beta'])
            RETURNING id::text AS id""",
@@ -123,7 +125,8 @@ def test_update_memory_enqueues_union_of_old_and_new_tags(_hooks_env):
     from ogham.database import get_backend
     from ogham.tools.memory import update_memory
 
-    row = get_backend()._execute(
+    backend = cast(Any, get_backend())
+    row = backend._execute(
         """INSERT INTO memories (content, profile, source, tags)
            VALUES ('body to edit', 'test-025', 't', ARRAY['alpha', 'beta'])
            RETURNING id::text AS id""",
@@ -148,7 +151,8 @@ def test_reinforce_memory_enqueues_current_tags(_hooks_env):
     from ogham.database import get_backend
     from ogham.tools.memory import reinforce_memory
 
-    row = get_backend()._execute(
+    backend = cast(Any, get_backend())
+    row = backend._execute(
         """INSERT INTO memories (content, profile, source, tags, confidence)
            VALUES ('reinforce me', 'test-025', 't', ARRAY['x', 'y'], 0.5)
            RETURNING id::text AS id""",
@@ -168,7 +172,8 @@ def test_contradict_memory_enqueues_current_tags(_hooks_env):
     from ogham.database import get_backend
     from ogham.tools.memory import contradict_memory
 
-    row = get_backend()._execute(
+    backend = cast(Any, get_backend())
+    row = backend._execute(
         """INSERT INTO memories (content, profile, source, tags, confidence)
            VALUES ('contradict me', 'test-025', 't', ARRAY['m', 'n'], 0.9)
            RETURNING id::text AS id""",

--- a/tests/test_onnx_embedder.py
+++ b/tests/test_onnx_embedder.py
@@ -1,5 +1,6 @@
 """Tests for the ONNX BGE-M3 embedding provider."""
 
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -178,8 +179,9 @@ class TestEncode:
 
         self._run_encode(token_ids, weights)
 
-        mod._session.run.assert_called_once()
-        output_names = mod._session.run.call_args[0][0]
+        session = cast(Any, mod._session)
+        session.run.assert_called_once()
+        output_names = session.run.call_args[0][0]
         assert output_names == ["dense_embeddings", "sparse_weights"]
 
 

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -8,8 +8,11 @@ Skip with: uv run pytest -m 'not postgres_integration'
 """
 
 from datetime import datetime, timedelta, timezone
+from typing import cast
 
 import pytest
+
+from ogham.backends.postgres import PostgresBackend
 
 TEST_PROFILE = "_test_postgres"
 OTHER_PROFILE = "_test_postgres_other"
@@ -22,8 +25,6 @@ def _can_connect() -> bool:
 
         if settings.database_backend != "postgres":
             return False
-        from ogham.backends.postgres import PostgresBackend
-
         backend = PostgresBackend()
         backend._execute("SELECT 1", fetch="scalar")
         return True
@@ -33,7 +34,6 @@ def _can_connect() -> bool:
 
 pytestmark = [
     pytest.mark.postgres_integration,
-    pytest.mark.skipif(not _can_connect(), reason="Postgres backend not configured or unreachable"),
 ]
 
 
@@ -44,13 +44,20 @@ def _fake_embedding(value: float = 0.1) -> list[float]:
     return [value] * settings.embedding_dim
 
 
+@pytest.fixture
+def postgres_available():
+    """Skip selected Postgres integration tests unless Postgres is reachable."""
+    if not _can_connect():
+        pytest.skip("Postgres backend not configured or unreachable")
+
+
 @pytest.fixture(autouse=True)
-def cleanup():
+def cleanup(postgres_available):
     """Delete all test data after each test."""
     yield
     from ogham.database import get_backend
 
-    backend = get_backend()
+    backend = cast(PostgresBackend, get_backend())
     backend._execute(
         "DELETE FROM memories WHERE profile = %(p)s",
         {"p": TEST_PROFILE},
@@ -80,7 +87,7 @@ def test_store_and_retrieve():
     """Store a memory and retrieve it via list_recent."""
     from ogham.database import get_backend
 
-    backend = get_backend()
+    backend = cast(PostgresBackend, get_backend())
     fake_emb = _fake_embedding()
     result = backend.store_memory(
         content="test memory for postgres",
@@ -100,7 +107,7 @@ def test_search_memories():
     """Store and search via match_memories RPC."""
     from ogham.database import get_backend
 
-    backend = get_backend()
+    backend = cast(PostgresBackend, get_backend())
     fake_emb = _fake_embedding()
     backend.store_memory(
         content="searchable postgres memory",
@@ -121,7 +128,7 @@ def test_hybrid_search():
     """Store and search via hybrid_search_memories RPC."""
     from ogham.database import get_backend
 
-    backend = get_backend()
+    backend = cast(PostgresBackend, get_backend())
     fake_emb = _fake_embedding()
     backend.store_memory(
         content="hybrid search postgres test",
@@ -141,7 +148,7 @@ def test_delete_memory():
     """Store and delete a memory."""
     from ogham.database import get_backend
 
-    backend = get_backend()
+    backend = cast(PostgresBackend, get_backend())
     fake_emb = _fake_embedding()
     mem = backend.store_memory(
         content="to be deleted",
@@ -158,7 +165,7 @@ def test_profile_stats():
     """get_memory_stats works via RPC."""
     from ogham.database import get_backend
 
-    backend = get_backend()
+    backend = cast(PostgresBackend, get_backend())
     fake_emb = _fake_embedding()
     backend.store_memory(
         content="stats test",
@@ -174,7 +181,7 @@ def test_profile_stats_health_counters():
     """get_memory_stats should return the additive health counters."""
     from ogham.database import get_backend
 
-    backend = get_backend()
+    backend = cast(PostgresBackend, get_backend())
     fake_emb = _fake_embedding()
 
     linked_a = backend.store_memory(
@@ -227,15 +234,15 @@ def test_profile_stats_health_counters():
 
     # The decay metric counts any active memory with importance > 0.05 that has
     # never been accessed or was last accessed more than 7 days ago. Seed the
-    # linked fixtures as recently accessed so only the explicit decay fixture is
-    # eligible.
+    # non-decay fixtures as recently accessed so only the explicit decay fixture
+    # is eligible.
     backend._execute(
         """UPDATE memories
            SET last_accessed_at = %(last_accessed_at)s
            WHERE id = ANY(%(ids)s::uuid[]) AND profile = %(profile)s""",
         {
             "last_accessed_at": datetime.now(timezone.utc),
-            "ids": [linked_a["id"], linked_b["id"]],
+            "ids": [linked_a["id"], linked_b["id"], cross_profile_only["id"]],
             "profile": TEST_PROFILE,
         },
         fetch="none",

--- a/tests/test_recompute.py
+++ b/tests/test_recompute.py
@@ -10,6 +10,7 @@ leaves-existing-row-intact (Letta #3270 guard).
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
@@ -61,7 +62,7 @@ def _seed_memories_with_tag(
 ) -> list[str]:
     from ogham.database import get_backend
 
-    backend = get_backend()
+    backend = cast(Any, get_backend())
     rows = backend._execute(
         """INSERT INTO memories (content, profile, source, tags)
            SELECT 'seed ' || i::text || ' content body for recompute tests',
@@ -161,6 +162,7 @@ def test_recompute_triggers_on_source_change(pg_fresh_db):
             profile="test-025", topic_key="quantum", provider="openai", model="gpt-4o"
         )
     v1 = get_summary_by_topic("test-025", "quantum")
+    assert v1 is not None
     assert v1["version"] == 1
 
     # Add one more source memory with the same tag.
@@ -178,6 +180,7 @@ def test_recompute_triggers_on_source_change(pg_fresh_db):
     assert out["source_count"] == 3
     assert syn.call_count == 1
     v2 = get_summary_by_topic("test-025", "quantum")
+    assert v2 is not None
     assert v2["version"] == 2
     assert v2["content"] == "v2"
 
@@ -203,6 +206,7 @@ def test_recompute_failure_leaves_existing_row_untouched(pg_fresh_db):
             profile="test-025", topic_key="quantum", provider="openai", model="gpt-4o"
         )
     before = get_summary_by_topic("test-025", "quantum")
+    assert before is not None
 
     # Add a new source so hash differs, forcing a recompile attempt.
     _seed_memories_with_tag(1, tag="quantum")
@@ -221,6 +225,7 @@ def test_recompute_failure_leaves_existing_row_untouched(pg_fresh_db):
             )
 
     after = get_summary_by_topic("test-025", "quantum")
+    assert after is not None
     assert after["id"] == before["id"]
     assert after["version"] == before["version"]
     assert after["content"] == before["content"]
@@ -262,7 +267,8 @@ def test_prompt_tokens_over_threshold_logs_warning(caplog, pg_fresh_db):
     # Create one big memory -- 45K chars -> ~11K tokens estimate.
     from ogham.database import get_backend
 
-    get_backend()._execute(
+    backend = cast(Any, get_backend())
+    backend._execute(
         """INSERT INTO memories (content, profile, source, tags)
            VALUES (%(c)s, 'test-025', 't', ARRAY['big'])""",
         {"c": "x" * 45000},

--- a/tests/test_stale_sweep.py
+++ b/tests/test_stale_sweep.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 
@@ -61,7 +62,7 @@ def _seed_summary_with_age(
     """
     from ogham.database import get_backend
 
-    backend = get_backend()
+    backend = cast(Any, get_backend())
     row = backend._execute(
         """INSERT INTO topic_summaries
              (topic_key, profile_id, content, source_count, source_hash, model_used)
@@ -105,7 +106,8 @@ def test_sweep_flips_old_fresh_to_stale(pg_fresh_db):
 
     from ogham.database import get_backend
 
-    row = get_backend()._execute(
+    backend = cast(Any, get_backend())
+    row = backend._execute(
         "SELECT status, stale_reason FROM topic_summaries WHERE id = %(id)s::uuid",
         {"id": sid},
         fetch="one",
@@ -125,7 +127,8 @@ def test_sweep_leaves_young_rows_alone(pg_fresh_db):
 
     from ogham.database import get_backend
 
-    row = get_backend()._execute(
+    backend = cast(Any, get_backend())
+    row = backend._execute(
         "SELECT status FROM topic_summaries WHERE id = %(id)s::uuid",
         {"id": sid},
         fetch="one",
@@ -144,12 +147,13 @@ def test_sweep_is_profile_scoped(pg_fresh_db):
 
     assert sweep_stale_summaries("test-025", older_than_days=30) == 1
 
-    status_a = get_backend()._execute(
+    backend = cast(Any, get_backend())
+    status_a = backend._execute(
         "SELECT status FROM topic_summaries WHERE id = %(id)s::uuid",
         {"id": sa},
         fetch="one",
     )
-    status_b = get_backend()._execute(
+    status_b = backend._execute(
         "SELECT status FROM topic_summaries WHERE id = %(id)s::uuid",
         {"id": sb},
         fetch="one",
@@ -158,7 +162,7 @@ def test_sweep_is_profile_scoped(pg_fresh_db):
     assert status_b["status"] == "fresh", "other profile must be untouched"
 
     # Cleanup -- test-025b leaks outside pg_fresh_db scope.
-    get_backend()._execute(
+    backend._execute(
         "DELETE FROM topic_summaries WHERE id = %(id)s::uuid",
         {"id": sb},
         fetch="none",
@@ -202,7 +206,8 @@ def test_session_start_hook_schedules_sweep(pg_fresh_db):
 
     from ogham.database import get_backend
 
-    row = get_backend()._execute(
+    backend = cast(Any, get_backend())
+    row = backend._execute(
         "SELECT status FROM topic_summaries "
         "WHERE topic_key = 'old-topic' AND profile_id = 'test-025'",
         {},

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -41,6 +41,7 @@ def reset_profile(monkeypatch):
 def mock_embedding():
     with (
         patch("ogham.tools.memory.generate_embedding") as mock,
+        patch("ogham.embeddings.generate_embedding", mock),
         patch("ogham.service.generate_embedding", mock),
     ):
         mock.return_value = [0.1] * 1024
@@ -504,6 +505,7 @@ def test_check_database_failure():
 
         assert result["status"] == "error"
         assert result["connected"] is False
+        assert isinstance(result["error"], str)
         assert "Connection refused" in result["error"]
 
 
@@ -567,6 +569,7 @@ def test_check_embedding_provider_openai_no_key():
         result = check_embedding_provider()
 
         assert result["status"] == "error"
+        assert isinstance(result["error"], str)
         assert "OPENAI_API_KEY not set" in result["error"]
 
 
@@ -597,6 +600,7 @@ def test_check_config_missing_url():
         result = check_config()
 
         assert result["status"] == "warning"
+        assert isinstance(result["issues"], list)
         assert "SUPABASE_URL not set" in result["issues"]
 
 
@@ -612,6 +616,7 @@ def test_check_config_unusual_embedding_dim():
         result = check_config()
 
         assert result["status"] == "warning"
+        assert isinstance(result["issues"], list)
         assert any("Unusual embedding_dim" in issue for issue in result["issues"])
 
 

--- a/tests/test_topic_summaries.py
+++ b/tests/test_topic_summaries.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import hashlib
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 
@@ -69,7 +70,7 @@ def _seed_memories(n: int = 3, profile: str = "test-025") -> list[str]:
     """
     from ogham.database import get_backend
 
-    backend = get_backend()
+    backend = cast(Any, get_backend())
     rows = backend._execute(
         """INSERT INTO memories (content, profile, source, tags)
            SELECT 'seed content row ' || i::text, %(profile)s, 't', ARRAY['ogham-memory']
@@ -176,7 +177,8 @@ def test_upsert_summary_updates_existing_row_and_replaces_sources(pg_fresh_db, p
     # Junction rows are replaced, not appended -- only v2 sources survive.
     from ogham.database import get_backend
 
-    rows = get_backend()._execute(
+    backend = cast(Any, get_backend())
+    rows = backend._execute(
         "SELECT memory_id::text AS mid FROM topic_summary_sources WHERE summary_id = %(id)s::uuid",
         {"id": str(s2["id"])},
         fetch="all",

--- a/tests/test_wiki_integration.py
+++ b/tests/test_wiki_integration.py
@@ -23,6 +23,7 @@ SQL surface is fully exercised.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
@@ -71,11 +72,7 @@ def _apply_028(pg_fresh_db):
     """
     pg_fresh_db.apply_sql(MIG_025)
     pg_fresh_db.apply_sql(MIG_026)
-    rollback_sql = DANGER_028.read_text()
-    pg_fresh_db.be._execute(
-        "SET ogham.confirm_rollback = 'I-KNOW-WHAT-I-AM-DOING';\n" + rollback_sql,
-        fetch="none",
-    )
+    pg_fresh_db.apply_rollback(DANGER_028)
     pg_fresh_db.apply_sql(MIG_028)
     pg_fresh_db.apply_sql(MIG_030)
     pg_fresh_db.apply_sql(MIG_031)
@@ -89,7 +86,7 @@ def _seed_memories_with_tag(
 ) -> list[str]:
     from ogham.database import get_backend
 
-    backend = get_backend()
+    backend = cast(Any, get_backend())
     rows = backend._execute(
         """INSERT INTO memories (content, profile, source, tags)
            SELECT %(prefix)s || ' ' || i::text, %(profile)s, 't', ARRAY[%(tag)s]
@@ -104,7 +101,7 @@ def _seed_memories_with_tag(
 def _add_relationship(source_id: str, target_id: str, rel: str, strength: float = 0.9):
     from ogham.database import get_backend
 
-    backend = get_backend()
+    backend = cast(Any, get_backend())
     backend._execute(
         """INSERT INTO memory_relationships
               (source_id, target_id, relationship, strength, created_by)
@@ -308,7 +305,7 @@ def test_find_orphans_surfaces_old_unlinked_memory(pg_fresh_db):
     # Backdate one row past the 5-min grace; leave the other inside it.
     from ogham.database import get_backend
 
-    backend = get_backend()
+    backend = cast(Any, get_backend())
     backend._execute(
         "UPDATE memories SET created_at = now() - interval '10 minutes' WHERE id = %(id)s::uuid",
         {"id": ids[0]},

--- a/uv.lock
+++ b/uv.lock
@@ -1505,6 +1505,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1591,6 +1600,7 @@ dashboard = [
     { name = "uvicorn" },
 ]
 dev = [
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
@@ -1615,6 +1625,7 @@ voyage = [
 [package.dev-dependencies]
 dev = [
     { name = "matplotlib" },
+    { name = "pyright" },
 ]
 
 [package.metadata]
@@ -1640,6 +1651,7 @@ requires-dist = [
     { name = "psycopg-pool", marker = "extra == 'all'", specifier = ">=3.1" },
     { name = "psycopg-pool", marker = "extra == 'postgres'", specifier = ">=3.1" },
     { name = "pydantic-settings", specifier = ">=2.0" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.409" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "python-dotenv", specifier = ">=1.0" },
@@ -1656,7 +1668,10 @@ requires-dist = [
 provides-extras = ["dev", "postgres", "mistral", "voyage", "gemini", "rerank", "dashboard", "all"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "matplotlib", specifier = ">=3.10.8" }]
+dev = [
+    { name = "matplotlib", specifier = ">=3.10.8" },
+    { name = "pyright", specifier = ">=1.1.409" },
+]
 
 [[package]]
 name = "ollama"
@@ -2305,6 +2320,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.409"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds Pyright as a lightweight type-safety quality gate for the repository. The goal is to make the same class of issues surfaced by Pylance reproducible in terminal, pre-commit, and CI, without changing runtime behavior.

## What changed

- Add `pyrightconfig.json` in standard mode for `src` and `tests`.
- Add Pyright to dev dependencies, `make lint`, and pre-commit.
- Add a conventional `Quality` GitHub Actions workflow that runs Ruff, format check, Pyright, and non-integration tests.
- Tighten annotations and typed boundaries around backend/database/test code where Pyright exposed ambiguous or unsafe types.
- Clarify one Postgres integration fixture so the decay health-counter assertion matches the SQL eligibility rule.
- Keep optional dependency imports as warnings instead of errors, since those packages are intentionally not always installed.

## Protocol surface notes

These are backward-compatible protocol/backend surface cleanups made while tightening typed boundaries:

- `protocol.py::store_memory` now includes `importance: float = 0.5` and `surprise: float = 0.5`; existing callers remain compatible through defaults.
- `protocol.py::emit_audit_event` now exposes its audit fields as 12 explicit named parameters instead of accepting arbitrary `**kwargs: Any`.
- `supabase.py` now provides a `spread_entity_activation` stub returning `[]`, replacing the previous missing-method `AttributeError` behavior.

## Why

Pylance currently reports type issues only inside an editor session, which makes type safety hard to reproduce during review. This PR turns that signal into a standard repository check so contributors can run the same validation locally and CI can prevent regressions.

## Compatibility and scope

This is intended to be backward compatible. The code changes are type-boundary cleanups, test fixture clarifications, and the protocol/backend surface cleanups noted above.

The PR intentionally avoids unrelated recall/inscribe or wiki behavior changes. A small set of wiki-specific files is excluded from the first Pyright gate because upstream tests and migration rollback references need separate cleanup.

## Validation

- `make lint` passes: Ruff, format check, Pyright `0 errors`.
- Non-integration tests pass locally: `620 passed, 3 skipped, 108 deselected`.
- Unblocked Postgres integration slice passes locally against a fresh scratch DB: `39 passed`.
- GitHub Actions are passing on this PR.

Full local integration still hits existing upstream test-harness blockers unrelated to this change: several tests reference renamed rollback files such as `028_topic_summaries_rollback.sql`, and `tests/test_lifecycle_parity.py` points at a hard-coded local Go binary path.
