### PR TITLE
feat(hooks): add smart inscribe extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ ogham cleanup                   # Remove expired memories
 ogham hooks install             # Auto-detect client + configure hooks
 ogham hooks recall              # Read from the stone (load project context)
 ogham hooks inscribe            # Carve into the stone (capture activity)
+ogham hooks inscribe --dry-run  # Preview hook memory without storing
 ogham serve                     # Start MCP server (stdio, default)
 ogham serve --transport sse     # Start SSE server on port 8742
 ogham openapi                   # Generate OpenAPI spec

--- a/docs/internals/hooks.md
+++ b/docs/internals/hooks.md
@@ -14,6 +14,11 @@
 - Decides whether the tool execution is worth storing as a memory
 - Implements multi-layer filtering to avoid noise
 
+### `user_prompt_submit(prompt, cwd, session_id, profile)`
+- Called for `UserPromptSubmit` hook events
+- Captures durable user-stated preferences, decisions, facts, corrections, and personal context
+- Skips short prompts and pure questions
+
 ### `pre_compact(session_id, cwd, profile)`
 - Drains session context to ogham before Claude Code compacts conversation
 - Stores a timestamped "session drain" marker
@@ -36,22 +41,50 @@ The `post_tool` hook applies several filters before storing:
 - `TaskCreate`, `TaskUpdate`, `TaskGet`, `TaskList`, `TaskOutput` — task management noise
 - `ToolSearch`, `Skill`, `AskUserQuestion`
 
-### 3. Noise command filtering (Bash)
+### 3. Response-gated tools
+- `Edit` is captured only when the old/new snippet yields a meaningful code-change memory
+- `Write` is captured only when it looks like a new file with a useful docstring/comment summary
+- Tiny typo edits and overwrites are skipped
+
+### 4. Noise command filtering (Bash)
 - Skips: `ls`, `pwd`, `cd`, `cat`, `head`, `tail`, `wc`, `echo`, `date`, `whoami`, `which`, `type`, `clear`, `history`
 
-### 4. Git filtering
+### 5. Git filtering
 - **Signal** (capture): `commit`, `push`, `merge`, `rebase`, `tag`, `release`, `reset`, `revert`, `cherry-pick`
 - **Noise** (skip): `add`, `status`, `diff`, `log`, `show`, `branch`, `checkout`, `switch`, `fetch`, `pull`, `stash`, `clean`, `gc`, `remote`, `config`
 - Unknown git subcommands: only captured if they contain signal keywords
 
-### 5. Signal keyword requirement (Bash)
+### 6. Bash response extraction
+- `git commit -m ...` stores the human commit message
+- failed commands store the first useful error line from `tool_response`
+- publish/deploy/release commands store the outcome when it can be extracted
+- `gh pr/issue/release` commands store the PR, issue, or release action
+
+### 7. Signal keyword requirement (Bash)
 - For routine tools (currently just Bash), content must contain at least one signal keyword to be captured
 - Keywords cover: errors, decisions, infrastructure, DevOps, testing, security, database, workarounds, package management
 
-### 6. Session dedup
+### 8. Importance gate
+- Hook-derived memory candidates are scored with the existing no-LLM importance heuristic
+- Low-value candidates are skipped before storage
+
+### 9. Session dedup
 - Tracks `(session_id, tool_name, target_path)` tuples with timestamps
 - Same `(tool, target)` within 5 minutes is suppressed
 - Entries older than 30 minutes are pruned
+
+## User Prompt Capture
+
+`UserPromptSubmit` capture is intentionally narrower than raw chat logging:
+
+- Skips short prompts such as "yes" or "try again"
+- Skips pure questions such as "what should we use?"
+- Captures explicit preferences, decisions, corrections, dated facts, and personal context
+- Stores the user's wording, with secrets masked, because the user-authored sentence is usually the best memory
+
+## Dry Run
+
+Use `ogham hooks inscribe --dry-run` with a real hook payload to preview the memory that would be stored. Dry-run mode does not write to Ogham and does not update hook deduplication state.
 
 ## Secret Masking (`_mask_secrets`)
 
@@ -70,6 +103,7 @@ Hooks config is loaded from `hooks_config.yaml` (YAML file adjacent to `hooks.py
 - Signal keywords
 - Noise commands
 - Always-skip tools
+- Response-gated tools
 - Routine tools
 - Git signal/noise subcommands
 - Secret detection patterns

--- a/src/ogham/hooks.py
+++ b/src/ogham/hooks.py
@@ -11,7 +11,10 @@ Codex/Cursor/OpenCode (CLAUDE.md fallback).
 import logging
 import os
 import re
+import shlex
+from dataclasses import dataclass
 from datetime import datetime, timezone
+from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any
 
@@ -35,8 +38,6 @@ _ALWAYS_SKIP_TOOLS = frozenset(
         "Glob",
         "Grep",
         "ListDir",
-        "Edit",
-        "Write",
         "NotebookEdit",
         "WebFetch",
         "WebSearch",
@@ -55,6 +56,59 @@ _ALWAYS_SKIP_TOOLS = frozenset(
         "CronDelete",
         "CronList",
     }
+)
+
+_DEFAULT_RESPONSE_GATED_TOOLS = frozenset({"Edit", "Write"})
+_HIGH_SIGNAL_TAGS = frozenset(
+    {
+        "type:code-change",
+        "type:context",
+        "type:correction",
+        "type:decision",
+        "type:deploy",
+        "type:error",
+        "type:fact",
+        "type:git-signal",
+        "type:preference",
+    }
+)
+_QUESTION_STARTS = (
+    "what ",
+    "how ",
+    "can you",
+    "why ",
+    "where ",
+    "when ",
+    "show me",
+)
+_PREFERENCE_MARKERS = (
+    "prefer",
+    "favorite",
+    "favourite",
+    "always use",
+    "rather",
+    "like better",
+)
+_DECISION_MARKERS = (
+    "decided",
+    "let's go with",
+    "lets go with",
+    "chose",
+    "going with",
+    "switching to",
+)
+_CORRECTION_MARKERS = (
+    "actually",
+    "correction",
+    "wrong",
+    "instead",
+)
+_PERSONAL_CONTEXT_MARKERS = (
+    "i'm based in",
+    "i am based in",
+    "i work at",
+    "my company",
+    "my team",
 )
 
 # --- Config loading ---
@@ -117,6 +171,14 @@ def _get_always_skip_tools() -> frozenset[str]:
     if cfg and "always_skip_tools" in cfg:
         return frozenset(cfg["always_skip_tools"])
     return _ALWAYS_SKIP_TOOLS
+
+
+def _get_response_gated_tools() -> frozenset[str]:
+    """Get tools captured only when their response/input yields a useful memory."""
+    cfg = _load_config()
+    if cfg and "response_gated_tools" in cfg:
+        return frozenset(cfg["response_gated_tools"])
+    return _DEFAULT_RESPONSE_GATED_TOOLS
 
 
 def _get_routine_tools() -> frozenset[str]:
@@ -382,8 +444,15 @@ _DEFAULT_ENV_SECRET_KEYS = frozenset(
     }
 )
 
-# High-value tool input fields to extract for summaries
-_SUMMARY_FIELDS = ("command", "content", "query", "file_path", "url", "message")
+
+@dataclass(frozen=True)
+class _HookMemory:
+    """A candidate memory extracted from one hook event."""
+
+    content: str
+    target: str = ""
+    tags: tuple[str, ...] = ()
+
 
 # --- Session dedup ---
 # Track recent (tool, target) pairs to collapse repeated edits to the same file.
@@ -451,6 +520,340 @@ def _type_tags(memory: dict[str, Any]) -> list[str]:
     return [tag for tag in raw_tags if isinstance(tag, str) and tag.startswith("type:")]
 
 
+def _squash(text: str, limit: int = 200) -> str:
+    """Collapse whitespace and cap hook-derived snippets."""
+    squashed = " ".join(text.strip().split())
+    return squashed[:limit].rstrip()
+
+
+def _string_literals(text: str) -> set[str]:
+    return {
+        match.group(1) or match.group(2)
+        for match in re.finditer(r'"([^"]+)"|\'([^\']+)\'', text)
+        if match.group(1) or match.group(2)
+    }
+
+
+def _diff_change_size(old: str, new: str) -> int:
+    """Approximate number of changed characters between two short snippets."""
+    matcher = SequenceMatcher(a=old, b=new, autojunk=False)
+    return sum(
+        max(i2 - i1, j2 - j1) for tag, i1, i2, j1, j2 in matcher.get_opcodes() if tag != "equal"
+    )
+
+
+def _extract_assignment(line: str) -> tuple[str, str] | None:
+    match = re.match(r"\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.+?)\s*,?\s*$", line, re.S)
+    if not match:
+        return None
+    return match.group(1), _squash(match.group(2), 80)
+
+
+def _extract_edit_memory(tool_input: dict[str, Any], cwd: str) -> _HookMemory | None:
+    file_path = str(tool_input.get("file_path") or tool_input.get("path") or "")
+    old = str(tool_input.get("old_string") or "")
+    new = str(tool_input.get("new_string") or "")
+    if not file_path or not old or not new or old == new:
+        return None
+
+    basename = os.path.basename(file_path)
+    target = file_path
+
+    old_literals = _string_literals(old)
+    new_literals = _string_literals(new)
+    added_literals = sorted(new_literals - old_literals)
+    assignee = _extract_assignment(new) or _extract_assignment(old)
+    if assignee and added_literals:
+        added = ", ".join(added_literals[:5])
+        return _HookMemory(
+            f"{basename}: added {added} to {assignee[0]}",
+            target=target,
+            tags=("type:code-change",),
+        )
+
+    old_def = re.search(r"\bdef\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)", old)
+    new_def = re.search(r"\bdef\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)", new)
+    if old_def and new_def and old_def.group(1) == new_def.group(1):
+        if old_def.group(2) != new_def.group(2):
+            return _HookMemory(
+                f"{basename}: changed signature for {new_def.group(1)}",
+                target=target,
+                tags=("type:code-change",),
+            )
+
+    old_assignment = _extract_assignment(old)
+    new_assignment = _extract_assignment(new)
+    if old_assignment and new_assignment and old_assignment[0] == new_assignment[0]:
+        content = (
+            f"{basename}: changed {new_assignment[0]} "
+            f"from {old_assignment[1]} to {new_assignment[1]}"
+        )
+        return _HookMemory(
+            content,
+            target=target,
+            tags=("type:code-change",),
+        )
+
+    if _diff_change_size(old, new) < 20:
+        return None
+
+    name_match = re.search(
+        r"\b(?:def|class)\s+([A-Za-z_][A-Za-z0-9_]*)|([A-Z_][A-Z0-9_]{2,})",
+        new,
+    )
+    subject = name_match.group(1) or name_match.group(2) if name_match else ""
+    if subject:
+        content = f"{basename}: changed {subject}"
+    else:
+        content = f"{basename}: changed {_squash(new, 120)}"
+    return _HookMemory(content, target=target, tags=("type:code-change",))
+
+
+def _first_doc_or_comment(content: str) -> str:
+    stripped = content.lstrip()
+    doc_match = re.match(r'(?s)(?:"""|\'\'\')\s*(.+?)(?:"""|\'\'\')', stripped)
+    if doc_match:
+        return _squash(doc_match.group(1), 120)
+    for line in stripped.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if line.startswith("#"):
+            return _squash(line.lstrip("# "), 120)
+        break
+    return ""
+
+
+def _extract_write_memory(
+    tool_input: dict[str, Any],
+    tool_response: str,
+    cwd: str,
+) -> _HookMemory | None:
+    file_path = str(tool_input.get("file_path") or tool_input.get("path") or "")
+    content = str(tool_input.get("content") or "")
+    if not file_path or not content:
+        return None
+
+    response_lower = tool_response.lower()
+    if any(word in response_lower for word in ("overwrote", "overwrite", "updated existing")):
+        return None
+    if response_lower and not any(
+        word in response_lower for word in ("created", "new file", "wrote")
+    ):
+        return None
+    if not response_lower:
+        return None
+
+    basename = os.path.basename(file_path)
+    description = _first_doc_or_comment(content)
+    if description:
+        memory = f"created {basename}: {description}"
+    else:
+        memory = f"created {basename}"
+    return _HookMemory(memory, target=file_path, tags=("type:code-change",))
+
+
+def _parse_shell(command: str) -> list[str]:
+    try:
+        return shlex.split(command)
+    except ValueError:
+        return command.split()
+
+
+def _git_commit_message(parts: list[str]) -> str | None:
+    for i, part in enumerate(parts):
+        if part in ("-m", "--message") and i + 1 < len(parts):
+            return parts[i + 1]
+        if part.startswith("-m") and len(part) > 2:
+            return part[2:]
+        if part.startswith("--message="):
+            return part.split("=", 1)[1]
+    return None
+
+
+def _extract_error_line(tool_response: str) -> str | None:
+    for line in tool_response[:2000].splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if re.search(r"\b\w*(?:Error|Exception)\b|Traceback|FAILED|error:", stripped, re.I):
+            stripped = re.sub(r"\b(\w*(?:Error|Exception)):\s*", r"\1 ", stripped)
+            return _squash(stripped, 200)
+    return None
+
+
+def _extract_publish_outcome(command: str, tool_response: str) -> str:
+    combined = f"{command}\n{tool_response[:2000]}"
+    version = re.search(r"\b(?:Published|version|v)(?:\s+)?v?(\d+\.\d+\.\d+)\b", combined, re.I)
+    if version:
+        return f"published {version.group(1)}"
+    return f"deploy/release command completed: {_squash(command, 120)}"
+
+
+def _extract_gh_memory(parts: list[str], tool_response: str) -> _HookMemory | None:
+    if len(parts) < 3 or parts[0] != "gh":
+        return None
+    noun, action = parts[1], parts[2]
+    if noun == "pr" and action == "merge":
+        pr_number = next((p for p in parts[3:] if p.isdigit()), "")
+        mode = "squash" if "--squash" in parts else "merge"
+        suffix = f" #{pr_number}" if pr_number else ""
+        return _HookMemory(f"merged PR{suffix} ({mode})", tags=("type:decision",))
+    if noun == "pr" and action in {"create", "close"}:
+        title_match = re.search(r"title:\s*(.+)", tool_response, re.I)
+        title = f": {_squash(title_match.group(1), 120)}" if title_match else ""
+        return _HookMemory(f"{action}d PR{title}", tags=("type:decision",))
+    if noun == "issue" and action == "close":
+        issue_number = next((p for p in parts[3:] if p.isdigit()), "")
+        suffix = f" #{issue_number}" if issue_number else ""
+        return _HookMemory(f"closed issue{suffix}", tags=("type:decision",))
+    if noun == "release" and action == "create":
+        version = parts[3] if len(parts) > 3 else ""
+        suffix = f" {version}" if version else ""
+        return _HookMemory(f"created GitHub release{suffix}", tags=("type:deploy",))
+    return None
+
+
+def _extract_bash_memory(
+    tool_input: dict[str, Any],
+    tool_response: str,
+    cwd: str,
+) -> _HookMemory | None:
+    command = str(tool_input.get("command") or "")
+    if not command:
+        return None
+    target = str(tool_input.get("file_path") or tool_input.get("path") or "")
+    command_lower = command.lower().strip()
+    parts = _parse_shell(command)
+    first = parts[0].lower() if parts else ""
+
+    if first in _get_noise_commands():
+        return None
+
+    exit_code = tool_input.get("exit_code")
+    if exit_code is None:
+        exit_code = tool_input.get("return_code")
+    error_line = _extract_error_line(tool_response)
+    if error_line and (exit_code not in (0, "0") or "error" in error_line.lower()):
+        return _HookMemory(f"error: {error_line}", target=target, tags=("type:error",))
+
+    gh_memory = _extract_gh_memory(parts, tool_response)
+    if gh_memory:
+        return _HookMemory(gh_memory.content, target=target, tags=gh_memory.tags)
+
+    if first == "git" and len(parts) > 1:
+        subcommand = parts[1].lower()
+        if subcommand in _get_git_noise():
+            return None
+        if subcommand == "commit":
+            message = _git_commit_message(parts)
+            if not message:
+                response_match = re.search(r"\[[^\]]+\]\s+(.+)", tool_response)
+                message = response_match.group(1) if response_match else None
+            if message:
+                return _HookMemory(
+                    f"git commit: {_squash(message, 160)}",
+                    target=target,
+                    tags=("type:decision",),
+                )
+        if subcommand in _get_git_signal():
+            return _HookMemory(
+                f"git {subcommand}: {_squash(command, 160)}",
+                target=target,
+                tags=("type:git-signal",),
+            )
+        if not any(kw in command_lower for kw in _get_signal_keywords()):
+            return None
+
+    if re.search(r"\b(publish|deploy|release)\b", command_lower):
+        return _HookMemory(
+            _extract_publish_outcome(command, tool_response),
+            target=target,
+            tags=("type:deploy",),
+        )
+
+    if first == "gh":
+        return None
+
+    if not any(kw in command_lower for kw in _get_signal_keywords()):
+        return None
+    return _HookMemory(f"Bash: {_squash(command, 160)}", target=target, tags=("type:action",))
+
+
+def _extract_memory_content(
+    event_type: str,
+    tool_name: str,
+    tool_input: dict[str, Any],
+    tool_response: str,
+    cwd: str,
+    prompt: str = "",
+) -> _HookMemory | None:
+    """Extract a useful memory from a hook event."""
+    if event_type == "UserPromptSubmit":
+        return _extract_user_prompt_memory(prompt, cwd)
+
+    if tool_name == "Edit":
+        return _extract_edit_memory(tool_input, cwd)
+    if tool_name == "Write":
+        return _extract_write_memory(tool_input, tool_response, cwd)
+    if tool_name == "Bash":
+        return _extract_bash_memory(tool_input, tool_response[:2000], cwd)
+    return None
+
+
+def _classify_user_prompt(prompt: str) -> tuple[bool, tuple[str, ...]]:
+    prompt_lower = prompt.lower().strip()
+    tags: list[str] = []
+
+    if any(marker in prompt_lower for marker in _PREFERENCE_MARKERS):
+        tags.append("type:preference")
+    if any(marker in prompt_lower for marker in _DECISION_MARKERS):
+        tags.append("type:decision")
+    if any(marker in prompt_lower for marker in _CORRECTION_MARKERS):
+        tags.append("type:correction")
+    if any(marker in prompt_lower for marker in _PERSONAL_CONTEXT_MARKERS):
+        tags.append("type:context")
+
+    try:
+        from ogham.extraction import extract_dates
+
+        if extract_dates(prompt):
+            tags.append("type:fact")
+    except Exception:
+        logger.debug("user prompt date extraction failed", exc_info=True)
+
+    return bool(tags), tuple(dict.fromkeys(tags))
+
+
+def _extract_user_prompt_memory(prompt: str, cwd: str) -> _HookMemory | None:
+    """Extract durable user-stated context from natural-language prompts."""
+    prompt = _squash(prompt, 500)
+    if len(prompt) < 30:
+        return None
+
+    prompt_lower = prompt.lower().strip()
+    if any(prompt_lower.startswith(q) for q in _QUESTION_STARTS):
+        return None
+
+    has_signal, tags = _classify_user_prompt(prompt)
+    if not has_signal:
+        return None
+
+    return _HookMemory(prompt, tags=tags)
+
+
+def _passes_importance_gate(content: str, tags: list[str]) -> bool:
+    """Reuse Ogham's existing no-LLM importance heuristic for hook captures."""
+    if any(tag in _HIGH_SIGNAL_TAGS for tag in tags):
+        return True
+    try:
+        from ogham.extraction import compute_importance
+
+        return compute_importance(content) >= 0.3
+    except Exception:
+        return True
+
+
 def session_start(
     cwd: str,
     profile: str = "work",
@@ -515,7 +918,24 @@ def session_start(
     return "\n".join(lines)
 
 
-def post_tool(hook_input: dict[str, Any], profile: str = "work") -> None:
+def _event_type(hook_input: dict[str, Any]) -> str:
+    raw = (
+        hook_input.get("hook_event_name") or hook_input.get("event") or hook_input.get("event_name")
+    )
+    if raw:
+        return str(raw)
+    if hook_input.get("tool_name"):
+        return "PostToolUse"
+    if hook_input.get("prompt") or hook_input.get("user_prompt"):
+        return "UserPromptSubmit"
+    return ""
+
+
+def post_tool(
+    hook_input: dict[str, Any],
+    profile: str = "work",
+    dry_run: bool = False,
+) -> str | None:
     """Capture a tool execution as a memory.
 
     Skips Ogham's own tools to prevent infinite loops.
@@ -524,72 +944,61 @@ def post_tool(hook_input: dict[str, Any], profile: str = "work") -> None:
 
     # Skip Ogham's own tools (infinite loop prevention)
     if any(tool_name.startswith(p) for p in _SKIP_PREFIXES):
-        return
+        return None
 
     # Skip tools that are always noise (reconnaissance, not action)
     if tool_name in _get_always_skip_tools():
-        return
+        return None
 
     tool_input = hook_input.get("tool_input", {})
+    if not isinstance(tool_input, dict):
+        tool_input = {"input": tool_input}
+    tool_response = str(
+        hook_input.get("tool_response")
+        or hook_input.get("response")
+        or hook_input.get("tool_output")
+        or hook_input.get("output")
+        or ""
+    )
     cwd = str(hook_input.get("cwd", ""))
     session_id = str(hook_input.get("session_id", ""))
 
-    # Extract summary from tool input
-    summary = ""
-    target_path = ""
-    if isinstance(tool_input, dict):
-        # Grab the target file/path for dedup
-        target_path = str(tool_input.get("file_path", tool_input.get("path", "")))
-        for field in _SUMMARY_FIELDS:
-            if field in tool_input:
-                summary = str(tool_input[field])[:200]
-                break
-        if not summary:
-            summary = str(tool_input)[:200]
-    else:
-        summary = str(tool_input)[:200]
+    if tool_name not in _get_routine_tools() and tool_name not in _get_response_gated_tools():
+        return None
 
-    summary_lower = summary.lower()
-
-    # Skip pure noise commands (ls, pwd, cat, etc.)
-    git_signal_match = False
-    if tool_name == "Bash":
-        parts = summary_lower.strip().split()
-        cmd_word = parts[0] if parts else ""
-        if cmd_word in _get_noise_commands():
-            return
-        if cmd_word in ("git", "gh") and len(parts) > 1:
-            git_sub = parts[1]
-            if git_sub in _get_git_noise():
-                return
-            if git_sub in _get_git_signal():
-                git_signal_match = True
-            elif cmd_word == "gh":
-                git_signal_match = True
-            elif not any(kw in summary_lower for kw in _get_signal_keywords()):
-                return
-
-    if tool_name in _get_routine_tools() and not git_signal_match:
-        if not any(kw in summary_lower for kw in _get_signal_keywords()):
-            return
+    extracted = _extract_memory_content(
+        "PostToolUse",
+        tool_name,
+        tool_input,
+        tool_response[:2000],
+        cwd,
+    )
+    if extracted is None:
+        return None
 
     # Dedup: skip if same (tool, target) was captured recently in this session
-    if target_path and _is_duplicate(session_id, tool_name, target_path):
-        logger.debug("post_tool: dedup skip %s on %s", tool_name, target_path)
-        return
+    if extracted.target and not dry_run and _is_duplicate(session_id, tool_name, extracted.target):
+        logger.debug("post_tool: dedup skip %s on %s", tool_name, extracted.target)
+        return None
 
     # Mask any secrets before storing
-    summary = _mask_secrets(summary)
+    content = _mask_secrets(extracted.content)
 
-    # Build content -- use file basename for readability
-    target_display = os.path.basename(target_path) if target_path else ""
-    if target_display:
-        content = f"{tool_name} {target_display}: {summary[:150]}"
-    else:
-        content = f"{tool_name}: {summary[:150]}"
     if cwd:
         project = os.path.basename(cwd)
         content += f" [{project}]"
+
+    tags = [
+        "type:action",
+        f"tool:{tool_name}",
+        f"session:{session_id}",
+        *extracted.tags,
+    ]
+    if not _passes_importance_gate(content, list(extracted.tags)):
+        return None
+
+    if dry_run:
+        return content
 
     try:
         from ogham.service import store_memory_enriched
@@ -598,17 +1007,57 @@ def post_tool(hook_input: dict[str, Any], profile: str = "work") -> None:
             content=content,
             profile=profile,
             source="hook:post-tool",
-            tags=["type:action", f"tool:{tool_name}", f"session:{session_id}"],
+            tags=tags,
         )
     except Exception:
         logger.debug("post_tool: store failed, ignoring")
+    return content
+
+
+def user_prompt_submit(
+    prompt: str,
+    cwd: str,
+    session_id: str = "",
+    profile: str = "work",
+    dry_run: bool = False,
+) -> str | None:
+    """Capture durable context from a user's natural-language prompt."""
+    extracted = _extract_memory_content("UserPromptSubmit", "", {}, "", cwd, prompt=prompt)
+    if extracted is None:
+        return None
+
+    content = _mask_secrets(extracted.content)
+    if cwd:
+        project = os.path.basename(cwd)
+        content += f" [{project}]"
+
+    tags = ["type:prompt", f"session:{session_id}", *extracted.tags]
+    if not _passes_importance_gate(content, list(extracted.tags)):
+        return None
+
+    if dry_run:
+        return content
+
+    try:
+        from ogham.service import store_memory_enriched
+
+        store_memory_enriched(
+            content=content,
+            profile=profile,
+            source="hook:user-prompt-submit",
+            tags=tags,
+        )
+    except Exception:
+        logger.debug("user_prompt_submit: store failed, ignoring")
+    return content
 
 
 def pre_compact(
     session_id: str,
     cwd: str,
     profile: str = "work",
-) -> None:
+    dry_run: bool = False,
+) -> str | None:
     """Drain session context to Ogham before compaction."""
     project_name = os.path.basename(cwd)
     timestamp = datetime.now(timezone.utc).isoformat()
@@ -621,6 +1070,9 @@ def pre_compact(
         f"Time: {timestamp}"
     )
 
+    if dry_run:
+        return content
+
     try:
         from ogham.service import store_memory_enriched
 
@@ -632,6 +1084,7 @@ def pre_compact(
         )
     except Exception:
         logger.debug("pre_compact: store failed, ignoring")
+    return content
 
 
 def post_compact(

--- a/src/ogham/hooks_cli.py
+++ b/src/ogham/hooks_cli.py
@@ -56,6 +56,32 @@ def _should_recall() -> bool:
     return True
 
 
+def _event_type(data: dict) -> str:
+    raw = data.get("hook_event_name") or data.get("event") or data.get("event_name")
+    if raw:
+        return str(raw)
+    if "tool_name" in data:
+        return "PostToolUse"
+    if _prompt_from_data(data):
+        return "UserPromptSubmit"
+    return ""
+
+
+def _prompt_from_data(data: dict) -> str:
+    for key in ("prompt", "user_prompt", "message"):
+        value = data.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return ""
+
+
+def _echo_dry_run(result: str | None) -> None:
+    if result:
+        typer.echo(result)
+    else:
+        typer.echo("No memory would be stored.")
+
+
 @hooks_app.command(name="recall")
 def recall_cmd(
     profile: str = typer.Option("work", help="Memory profile"),
@@ -81,9 +107,14 @@ def recall_cmd(
 @hooks_app.command(name="inscribe")
 def inscribe_cmd(
     profile: str = typer.Option("work", help="Memory profile"),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Preview the memory that would be stored without writing it",
+    ),
 ):
     """Carve into the stone. Capture activity or drain session before compaction."""
-    from ogham.hooks import post_tool, pre_compact
+    from ogham.hooks import post_tool, pre_compact, user_prompt_submit
 
     data = _read_stdin()
 
@@ -98,16 +129,32 @@ def inscribe_cmd(
             "session_id": "kiro",
         }
 
-    # If it looks like a tool call, capture as post_tool
-    if "tool_name" in data:
-        post_tool(data, profile=profile)
+    event = _event_type(data)
+
+    if event == "UserPromptSubmit":
+        result = user_prompt_submit(
+            prompt=_prompt_from_data(data),
+            cwd=data.get("cwd", "."),
+            session_id=data.get("session_id", "unknown"),
+            profile=profile,
+            dry_run=dry_run,
+        )
+        if dry_run:
+            _echo_dry_run(result)
+    elif "tool_name" in data:
+        result = post_tool(data, profile=profile, dry_run=dry_run)
+        if dry_run:
+            _echo_dry_run(result)
     else:
         # Otherwise treat as compaction drain
-        pre_compact(
+        result = pre_compact(
             session_id=data.get("session_id", "unknown"),
             cwd=data.get("cwd", "."),
             profile=profile,
+            dry_run=dry_run,
         )
+        if dry_run:
+            _echo_dry_run(result)
 
 
 @hooks_app.command(name="install")

--- a/src/ogham/hooks_config.yaml
+++ b/src/ogham/hooks_config.yaml
@@ -238,8 +238,7 @@ noise_commands:
   - help
 
 # Tools that are always noise -- never stored regardless of content.
-# Reconnaissance tools, file edits, web fetches, skill invocations, task management.
-# Only Bash (filtered by signal keywords) produces memories from tool use.
+# Reconnaissance tools, web fetches, skill invocations, task management.
 always_skip_tools:
   - ToolSearch
   - Skill
@@ -247,8 +246,6 @@ always_skip_tools:
   - Glob
   - Grep
   - ListDir
-  - Edit
-  - Write
   - NotebookEdit
   - WebFetch
   - WebSearch
@@ -266,6 +263,11 @@ always_skip_tools:
   - CronCreate
   - CronDelete
   - CronList
+
+# Tools that can produce useful memories only after inspecting the tool payload.
+response_gated_tools:
+  - Edit
+  - Write
 
 # Tools that are captured only if content contains signal keywords.
 # Bash is the main one -- ls/cat already filtered by noise_commands.

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -70,8 +70,7 @@ def test_post_tool_stores_action():
 
     mock_store.assert_called_once()
     content = mock_store.call_args.kwargs["content"]
-    assert "Bash" in content
-    assert "git commit" in content
+    assert "git commit: fix: update config" in content
 
 
 def test_post_tool_skips_ogham_tools():
@@ -120,11 +119,11 @@ def test_post_tool_skips_always_skip_tools():
         assert mock_store.call_count == 0, f"{tool_name} should be always-skipped"
 
 
-def test_post_tool_skips_edit_write_tools():
-    """Edit, Write, Agent, WebFetch are now skipped -- too noisy."""
+def test_post_tool_skips_non_response_gated_noise_tools():
+    """Agent and WebFetch remain skipped -- too noisy for hook capture."""
     from ogham.hooks import post_tool
 
-    for tool_name in ["Write", "Edit", "Agent", "WebFetch"]:
+    for tool_name in ["Agent", "WebFetch"]:
         with patch("ogham.service.store_memory_enriched") as mock_store:
             post_tool(
                 {
@@ -136,6 +135,147 @@ def test_post_tool_skips_edit_write_tools():
                 profile="work",
             )
         assert mock_store.call_count == 0, f"{tool_name} should be skipped"
+
+
+def test_post_tool_captures_edit_added_to_collection():
+    from ogham.hooks import post_tool
+
+    with patch("ogham.service.store_memory_enriched") as mock_store:
+        post_tool(
+            {
+                "tool_name": "Edit",
+                "tool_input": {
+                    "file_path": "/src/ogham/hooks.py",
+                    "old_string": 'ALWAYS_SKIP_TOOLS = frozenset({"Read", "Glob"})',
+                    "new_string": (
+                        'ALWAYS_SKIP_TOOLS = frozenset({"Read", "Glob", "Edit", "Write"})'
+                    ),
+                },
+                "cwd": "/Users/dev/ogham-mcp",
+                "session_id": "s1",
+            },
+            profile="work",
+        )
+
+    mock_store.assert_called_once()
+    content = mock_store.call_args.kwargs["content"]
+    assert content == "hooks.py: added Edit, Write to ALWAYS_SKIP_TOOLS [ogham-mcp]"
+    tags = mock_store.call_args.kwargs["tags"]
+    assert "tool:Edit" in tags
+    assert "type:code-change" in tags
+
+
+def test_post_tool_captures_edit_assignment_change():
+    from ogham.hooks import post_tool
+
+    with patch("ogham.service.store_memory_enriched") as mock_store:
+        post_tool(
+            {
+                "tool_name": "Edit",
+                "tool_input": {
+                    "file_path": "/src/ogham/config.py",
+                    "old_string": "x = 1",
+                    "new_string": "x = 2",
+                },
+                "cwd": "/Users/dev/ogham-mcp",
+                "session_id": "s1",
+            },
+            profile="work",
+        )
+
+    mock_store.assert_called_once()
+    content = mock_store.call_args.kwargs["content"]
+    assert content == "config.py: changed x from 1 to 2 [ogham-mcp]"
+
+
+def test_post_tool_skips_tiny_typo_edit():
+    from ogham.hooks import post_tool
+
+    with patch("ogham.service.store_memory_enriched") as mock_store:
+        post_tool(
+            {
+                "tool_name": "Edit",
+                "tool_input": {
+                    "file_path": "/src/ogham/README.md",
+                    "old_string": "teh",
+                    "new_string": "the",
+                },
+                "cwd": "/Users/dev/ogham-mcp",
+                "session_id": "s1",
+            },
+            profile="work",
+        )
+
+    mock_store.assert_not_called()
+
+
+def test_post_tool_captures_write_new_file_docstring():
+    from ogham.hooks import post_tool
+
+    with patch("ogham.service.store_memory_enriched") as mock_store:
+        post_tool(
+            {
+                "tool_name": "Write",
+                "tool_input": {
+                    "file_path": "/src/ogham/dashboard_server.py",
+                    "content": (
+                        '"""FastAPI standalone dashboard server."""\n\n'
+                        "from fastapi import FastAPI\n"
+                    ),
+                },
+                "tool_response": "Created file",
+                "cwd": "/Users/dev/ogham-mcp",
+                "session_id": "s1",
+            },
+            profile="work",
+        )
+
+    mock_store.assert_called_once()
+    content = mock_store.call_args.kwargs["content"]
+    assert content == (
+        "created dashboard_server.py: FastAPI standalone dashboard server. [ogham-mcp]"
+    )
+
+
+def test_post_tool_skips_write_overwrite():
+    from ogham.hooks import post_tool
+
+    with patch("ogham.service.store_memory_enriched") as mock_store:
+        post_tool(
+            {
+                "tool_name": "Write",
+                "tool_input": {
+                    "file_path": "/src/ogham/dashboard_server.py",
+                    "content": "# rewritten file\n",
+                },
+                "tool_response": "Updated existing file",
+                "cwd": "/Users/dev/ogham-mcp",
+                "session_id": "s1",
+            },
+            profile="work",
+        )
+
+    mock_store.assert_not_called()
+
+
+def test_post_tool_skips_write_without_creation_response():
+    from ogham.hooks import post_tool
+
+    with patch("ogham.service.store_memory_enriched") as mock_store:
+        post_tool(
+            {
+                "tool_name": "Write",
+                "tool_input": {
+                    "file_path": "/src/ogham/dashboard_server.py",
+                    "content": '"""FastAPI standalone dashboard server."""\n',
+                },
+                "cwd": "/Users/dev/ogham-mcp",
+                "session_id": "s1",
+            },
+            profile="work",
+        )
+
+    mock_store.assert_not_called()
 
 
 def test_post_tool_skips_noise_bash():
@@ -186,6 +326,227 @@ def test_post_tool_captures_signal_bash():
         assert mock_store.call_count == 1, f"{cmd!r} should be captured as signal"
 
 
+def test_post_tool_captures_bash_error_from_response():
+    from ogham.hooks import post_tool
+
+    with patch("ogham.service.store_memory_enriched") as mock_store:
+        post_tool(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "uv run pytest", "exit_code": 1},
+                "tool_response": (
+                    "ImportError: cannot import name 'task_redis_prefix' "
+                    "from 'fastmcp.server.tasks.keys'"
+                ),
+                "cwd": "/Users/dev/ogham-mcp",
+                "session_id": "s1",
+            },
+            profile="work",
+        )
+
+    mock_store.assert_called_once()
+    content = mock_store.call_args.kwargs["content"]
+    assert content.startswith("error: ImportError cannot import name")
+    tags = mock_store.call_args.kwargs["tags"]
+    assert "type:error" in tags
+
+
+def test_post_tool_captures_bash_deploy_outcome():
+    from ogham.hooks import post_tool
+
+    with patch("ogham.service.store_memory_enriched") as mock_store:
+        post_tool(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "uv publish --token pypi-FAKEFAKEFAKEFAKEFAKEFAKE"},
+                "tool_response": "Published 0.10.2",
+                "cwd": "/Users/dev/ogham-mcp",
+                "session_id": "s1",
+            },
+            profile="work",
+        )
+
+    mock_store.assert_called_once()
+    content = mock_store.call_args.kwargs["content"]
+    assert content == "published 0.10.2 [ogham-mcp]"
+    tags = mock_store.call_args.kwargs["tags"]
+    assert "type:deploy" in tags
+
+
+def test_post_tool_captures_gh_pr_merge():
+    from ogham.hooks import post_tool
+
+    with patch("ogham.service.store_memory_enriched") as mock_store:
+        post_tool(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "gh pr merge 37 --squash"},
+                "tool_response": "Merged pull request #37",
+                "cwd": "/Users/dev/ogham-mcp",
+                "session_id": "s1",
+            },
+            profile="work",
+        )
+
+    mock_store.assert_called_once()
+    content = mock_store.call_args.kwargs["content"]
+    assert content == "merged PR #37 (squash) [ogham-mcp]"
+
+
+@pytest.mark.parametrize(
+    ("command", "response", "expected"),
+    [
+        (
+            "gh pr create --title 'Add dashboard hooks'",
+            "title: Add dashboard hooks\nurl: https://github.com/x/y/pull/12",
+            "created PR: Add dashboard hooks [ogham-mcp]",
+        ),
+        (
+            "gh pr close 12",
+            "title: Close stale dashboard hooks PR",
+            "closed PR: Close stale dashboard hooks PR [ogham-mcp]",
+        ),
+        (
+            "gh issue close 44",
+            "Closed issue #44",
+            "closed issue #44 [ogham-mcp]",
+        ),
+    ],
+)
+def test_post_tool_captures_other_gh_actions(command, response, expected):
+    from ogham.hooks import post_tool
+
+    with patch("ogham.service.store_memory_enriched") as mock_store:
+        post_tool(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": command},
+                "tool_response": response,
+                "cwd": "/Users/dev/ogham-mcp",
+                "session_id": "s1",
+            },
+            profile="work",
+        )
+
+    mock_store.assert_called_once()
+    content = mock_store.call_args.kwargs["content"]
+    assert content == expected
+    tags = mock_store.call_args.kwargs["tags"]
+    assert "type:decision" in tags
+
+
+def test_post_tool_captures_gh_release_create():
+    from ogham.hooks import post_tool
+
+    with patch("ogham.service.store_memory_enriched") as mock_store:
+        post_tool(
+            {
+                "tool_name": "Bash",
+                "tool_input": {"command": "gh release create v0.10.3"},
+                "tool_response": "Created release v0.10.3",
+                "cwd": "/Users/dev/ogham-mcp",
+                "session_id": "s1",
+            },
+            profile="work",
+        )
+
+    mock_store.assert_called_once()
+    content = mock_store.call_args.kwargs["content"]
+    assert content == "created GitHub release v0.10.3 [ogham-mcp]"
+    tags = mock_store.call_args.kwargs["tags"]
+    assert "type:deploy" in tags
+
+
+def test_post_tool_dry_run_does_not_store_or_dedup():
+    from ogham.hooks import post_tool
+
+    hook_input = {
+        "tool_name": "Edit",
+        "tool_input": {
+            "file_path": "/src/ogham/config.py",
+            "old_string": "x = 1",
+            "new_string": "x = 2",
+        },
+        "cwd": "/Users/dev/ogham-mcp",
+        "session_id": "s1",
+    }
+
+    with patch("ogham.service.store_memory_enriched") as mock_store:
+        preview = post_tool(hook_input, profile="work", dry_run=True)
+        post_tool(hook_input, profile="work")
+
+    assert preview == "config.py: changed x from 1 to 2 [ogham-mcp]"
+    mock_store.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("prompt", "expected_tag"),
+    [
+        ("I prefer PostgreSQL over MySQL for this project", "type:preference"),
+        ("let's go with vendor X because the pricing is better", "type:decision"),
+        ("actually the API key goes in the header, not body", "type:correction"),
+        ("the project deadline is April 30 2026 for the launch", "type:fact"),
+        ("I'm based in Germany and work at Aldi on platform tooling", "type:context"),
+    ],
+)
+def test_user_prompt_submit_captures_normal_user_signals(prompt, expected_tag):
+    from ogham.hooks import user_prompt_submit
+
+    with patch("ogham.service.store_memory_enriched") as mock_store:
+        user_prompt_submit(
+            prompt=prompt,
+            cwd="/Users/dev/ogham-mcp",
+            session_id="s1",
+            profile="work",
+        )
+
+    mock_store.assert_called_once()
+    content = mock_store.call_args.kwargs["content"]
+    assert prompt in content
+    tags = mock_store.call_args.kwargs["tags"]
+    assert "type:prompt" in tags
+    assert expected_tag in tags
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        "yes",
+        "what database should we use for the project?",
+        "please run the tests again without changing anything",
+    ],
+)
+def test_user_prompt_submit_skips_low_signal_prompts(prompt):
+    from ogham.hooks import user_prompt_submit
+
+    with patch("ogham.service.store_memory_enriched") as mock_store:
+        result = user_prompt_submit(
+            prompt=prompt,
+            cwd="/Users/dev/ogham-mcp",
+            session_id="s1",
+            profile="work",
+        )
+
+    assert result is None
+    mock_store.assert_not_called()
+
+
+def test_user_prompt_submit_dry_run_does_not_store():
+    from ogham.hooks import user_prompt_submit
+
+    with patch("ogham.service.store_memory_enriched") as mock_store:
+        preview = user_prompt_submit(
+            prompt="I prefer PostgreSQL over MySQL for this project",
+            cwd="/Users/dev/ogham-mcp",
+            session_id="s1",
+            profile="work",
+            dry_run=True,
+        )
+
+    assert preview == "I prefer PostgreSQL over MySQL for this project [ogham-mcp]"
+    mock_store.assert_not_called()
+
+
 def test_post_tool_tags_include_tool_name():
     from ogham.hooks import post_tool
 
@@ -203,6 +564,7 @@ def test_post_tool_tags_include_tool_name():
     tags = mock_store.call_args.kwargs["tags"]
     assert "tool:Bash" in tags
     assert "type:action" in tags
+    assert "type:decision" in tags
     assert "session:s1" in tags
 
 

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -1,0 +1,58 @@
+"""Tests for hook CLI routing."""
+
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def test_hooks_inscribe_dry_run_previews_tool_memory():
+    from ogham.hooks_cli import hooks_app
+
+    data = {
+        "tool_name": "Bash",
+        "tool_input": {"command": "git commit -m 'feat: add dashboard'"},
+        "cwd": "/Users/dev/ogham-mcp",
+        "session_id": "s1",
+    }
+
+    with patch("ogham.hooks_cli._read_stdin", return_value=data):
+        result = runner.invoke(hooks_app, ["inscribe", "--dry-run"])
+
+    assert result.exit_code == 0
+    assert "git commit: feat: add dashboard [ogham-mcp]" in result.output
+
+
+def test_hooks_inscribe_dry_run_routes_user_prompt_submit():
+    from ogham.hooks_cli import hooks_app
+
+    data = {
+        "hook_event_name": "UserPromptSubmit",
+        "prompt": "I prefer PostgreSQL over MySQL for this project",
+        "cwd": "/Users/dev/ogham-mcp",
+        "session_id": "s1",
+    }
+
+    with patch("ogham.hooks_cli._read_stdin", return_value=data):
+        result = runner.invoke(hooks_app, ["inscribe", "--dry-run"])
+
+    assert result.exit_code == 0
+    assert "I prefer PostgreSQL over MySQL for this project [ogham-mcp]" in result.output
+
+
+def test_hooks_inscribe_dry_run_reports_skipped_memory():
+    from ogham.hooks_cli import hooks_app
+
+    data = {
+        "tool_name": "Bash",
+        "tool_input": {"command": "ls -la"},
+        "cwd": "/Users/dev/ogham-mcp",
+        "session_id": "s1",
+    }
+
+    with patch("ogham.hooks_cli._read_stdin", return_value=data):
+        result = runner.invoke(hooks_app, ["inscribe", "--dry-run"])
+
+    assert result.exit_code == 0
+    assert "No memory would be stored." in result.output


### PR DESCRIPTION
## Summary

Implements the smart inscribe hook expectations from `.idea/cemre-dashboard-hooks/2026-04-16-smart-inscribe-hooks.md` in one PR.

The core change is that inscribe hooks now capture what was learned, changed, decided, created, corrected, or failed instead of generic tool activity like `Edit README.md: /path`.

## Why

Blanket-skipping `Edit` and `Write` prevented noisy memory pollution, but it also dropped high-value engineering signals. This PR restores those surfaces through explicit extraction gates. It also adds the document's stretch goal for `UserPromptSubmit`, while keeping Stop/PreCompact summary redesign out of scope as requested by the expectation doc.

## What Changed

- Adds event-aware extraction through `_extract_memory_content(...)`.
- Adds response-gated `Edit` and `Write` handling:
  - captures meaningful assignment/list/function-signature changes,
  - skips tiny typo edits,
  - captures clearly new files from docstrings/comments,
  - skips ambiguous writes and overwrites.
- Improves `Bash` handling:
  - `git commit -m ...` stores the commit message,
  - errors are extracted from `tool_response`,
  - publish/deploy/release outcomes are summarized,
  - `gh pr merge/create/close`, `gh issue close`, and `gh release create` are parsed.
- Adds `UserPromptSubmit` capture for:
  - preferences,
  - decisions,
  - dated facts,
  - corrections,
  - personal/work context.
- Adds `ogham hooks inscribe --dry-run`:
  - previews what would be stored,
  - does not write,
  - does not mutate hook dedup state.
- Adds `response_gated_tools` to `hooks_config.yaml`.
- Updates README and hook internals docs.

## Requirement Coverage

- Edit meaningful diff capture: covered.
- Edit typo skip: covered.
- Write new file summary: covered.
- Write overwrite/ambiguous skip: covered.
- Bash commit message capture: covered.
- Bash error extraction from response: covered.
- Bash deploy/release extraction: covered.
- gh PR/issue/release extraction: covered.
- Noise commands and always-skip tools: preserved.
- Dry-run preview: covered.
- UserPromptSubmit stretch goal: covered.
- No LLM or direct embedding calls from hooks: preserved.
- Stop hook and smarter PreCompact summaries: intentionally not changed; the expectation doc says not to duplicate `/save-learnings` and to park PreCompact summaries for later.

## Tradeoffs

- Extractors are heuristic and no-LLM by design. This keeps hook latency low and predictable, but it will not perfectly summarize every possible diff.
- `Write` requires creation-like tool response text before capture. This is conservative, but safer than storing possible overwrites as new-file memories.
- `git push origin` remains a git signal rather than always a deploy. Some pushes deploy and some do not; explicit publish/deploy/release commands produce deploy memories.
- `hooks.py` is now larger. The logic still belongs near hook parsing for this PR, but future extractor growth should move into a private `hook_extractors.py`.

## Verification

- `env DATABASE_BACKEND=supabase SUPABASE_URL=https://fake.supabase.co SUPABASE_KEY=fake-key EMBEDDING_PROVIDER=ollama DEFAULT_PROFILE=default uv run pytest tests/test_hooks.py tests/test_hooks_cli.py` -> 48 passed
- `env DATABASE_BACKEND=supabase SUPABASE_URL=https://fake.supabase.co SUPABASE_KEY=fake-key EMBEDDING_PROVIDER=ollama DEFAULT_PROFILE=default uv run pytest` -> 718 passed, 119 skipped
- `uv run ruff check src tests` -> passed
- `uv run ruff format --check src tests` -> passed
- `uv run pyright` -> 0 errors
