### PR TITLE
build: v0.13.1 hotfix B + D — make tag guard + sdist exclude

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,20 @@ publish: build publish-check
 tag:
 	@VERSION=$$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])"); \
 	echo "=== Creating GitHub release v$$VERSION ==="; \
-	git add -A && git commit -m "v$$VERSION" --allow-empty; \
+	BEFORE_HEAD=$$(git rev-parse HEAD); \
+	git add -A; \
+	if ! git commit -m "v$$VERSION" --allow-empty; then \
+		echo "ERROR: 'git commit --allow-empty' returned non-zero -- pre-commit hook (prek/ruff/pyright) likely blocked the commit."; \
+		echo "       Run 'git commit --allow-empty -m \"v$$VERSION\"' manually to see the hook output, fix it, then re-run 'make tag'."; \
+		exit 1; \
+	fi; \
+	AFTER_HEAD=$$(git rev-parse HEAD); \
+	if [ "$$BEFORE_HEAD" = "$$AFTER_HEAD" ]; then \
+		echo "ERROR: HEAD did not move after 'git commit --allow-empty' (was $$BEFORE_HEAD, still $$BEFORE_HEAD)."; \
+		echo "       A pre-commit hook silently aborted the commit. Tagging this HEAD would publish stale code."; \
+		echo "       This was the root cause of the v0.13.0 ship incident -- do not bypass."; \
+		exit 1; \
+	fi; \
 	git push origin main; \
 	git tag -a "v$$VERSION" -m "v$$VERSION"; \
 	git push origin "v$$VERSION"; \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ exclude = [
     "**/*.pyc",
     "sql/migrations/DANGER_*",
     "sql/archive/",
+    "demo-scripts/",
 ]
 
 [build-system]


### PR DESCRIPTION
Two small build-system fixes for the v0.13.1 patch sweep.

## Hotfix B — \`make tag\` silent-failure guard

v0.13.0 shipped pointing at v0.12.1 code because pre-commit hook (prek) blocked \`git commit --allow-empty\` silently. The Makefile recipe used \`;\` separators after the failed commit, so the rest of the recipe ran and tagged the wrong HEAD.

Fix: capture HEAD before/after the commit and exit 1 with a clear error if it didn't move. Also wraps the commit in \`if ! ...; then\` so non-zero exit codes from the commit itself surface immediately.

\`\`\`
ERROR: HEAD did not move after 'git commit --allow-empty' (was abc123, still abc123).
       A pre-commit hook silently aborted the commit. Tagging this HEAD would
       publish stale code.
       This was the root cause of the v0.13.0 ship incident -- do not bypass.
\`\`\`

## Hotfix D — drop \`demo-scripts/\` from sdist

v0.13.0 sdist audit caught \`demo-scripts/README.md\` slipping into the tarball. Adding \`demo-scripts/\` to \`[tool.hatch.build.targets.sdist].exclude\` closes the leak.

## Test plan

- [x] \`make -n tag\` parses cleanly (Make recipe syntax valid)
- [x] Hotfix B fail-injection traced through manually: failed prek → \`git commit\` non-zero → \`if ! ...\` catches → exit 1 with message
- [ ] Live-fire the new \`make tag\` guard during the v0.13.1 release ship (this PR enables that test)

Pairs with the dev-side v0.13.1 release commit (forthcoming via \`make sync\`).