### PR TITLE
build(sync): close 8-file SYNC_SOURCES gap + glob migrations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,12 +45,23 @@ build: clean
 
 # --- Sync dev → public repo ---
 
-# Files to sync from dev to public
+# Files to sync from dev to public.
+#
+# v0.13.1 audit found 8 release-critical files were silently skipped by
+# this list (lifecycle.py + graph.py + tools/memory.py + new tests +
+# docs/internals/hooks.md). Adding them explicitly + globbing migrations
+# closes the v0.9.2 / v0.13.0 sync-gap class of bugs once and for all.
+#
+# Migrations are now globbed at sync time (see the sync target). Schemas
+# stay individually listed because they're hand-curated and we want the
+# explicit dev → public mapping visible at review time.
 SYNC_SOURCES := \
 	src/ogham/hooks.py \
 	src/ogham/hooks_cli.py \
 	src/ogham/hooks_install.py \
 	src/ogham/hooks_config.yaml \
+	src/ogham/lifecycle.py \
+	src/ogham/graph.py \
 	src/ogham/service.py \
 	src/ogham/database.py \
 	src/ogham/config.py \
@@ -63,9 +74,15 @@ SYNC_SOURCES := \
 	src/ogham/backends/postgres.py \
 	src/ogham/backends/supabase.py \
 	src/ogham/backends/gateway.py \
+	src/ogham/tools/memory.py \
+	src/ogham/tools/wiki.py \
+	src/ogham/tools/stats.py \
 	tests/test_hooks.py \
+	tests/test_hooks_cli.py \
 	tests/test_extraction.py \
 	tests/test_backend_wiring.py \
+	tests/test_supabase_lifecycle_graph_parity.py \
+	docs/internals/hooks.md \
 	sql/schema.sql \
 	sql/schema_postgres.sql \
 	sql/schema_selfhost_supabase.sql \
@@ -81,7 +98,21 @@ sync:
 			cp "$(DEV_REPO)/$$f" "$(PUB_REPO)/$$f"; \
 		fi; \
 	done
-	@echo "Synced $$(echo $(SYNC_SOURCES) | wc -w | tr -d ' ') files"
+	@echo "Synced $$(echo $(SYNC_SOURCES) | wc -w | tr -d ' ') tracked files"
+	@echo ""
+	@echo "--- Syncing sql/migrations/ (additive; never deletes public-only files) ---"
+	@mkdir -p "$(PUB_REPO)/sql/migrations"
+	@MIG_COUNT=0; for f in $(DEV_REPO)/sql/migrations/[0-9]*.sql; do \
+		if [ -f "$$f" ]; then \
+			cp "$$f" "$(PUB_REPO)/sql/migrations/" && MIG_COUNT=$$((MIG_COUNT+1)); \
+		fi; \
+	done; echo "Synced $$MIG_COUNT migration files"
+	@mkdir -p "$(PUB_REPO)/sql/migrations/rollback"
+	@RB_COUNT=0; for f in $(DEV_REPO)/sql/migrations/rollback/*.sql; do \
+		if [ -f "$$f" ]; then \
+			cp "$$f" "$(PUB_REPO)/sql/migrations/rollback/" && RB_COUNT=$$((RB_COUNT+1)); \
+		fi; \
+	done; echo "Synced $$RB_COUNT rollback files"
 	@echo ""
 	@echo "--- Changes in public repo ---"
 	@cd $(PUB_REPO) && git diff --stat HEAD


### PR DESCRIPTION
v0.13.1 ship audit caught the public Makefile's \`SYNC_SOURCES\` list silently skipping files that needed to flow from dev to public. Same class of bug that bit v0.9.2 (postgres.py PR type-cast not synced) and v0.13.0 (033/034 migrations had to be hand-copied). Closing the gap once instead of patching per-release.

## Files added to SYNC_SOURCES

- \`src/ogham/lifecycle.py\` -- v0.13.1 facade refactor (CRITICAL)
- \`src/ogham/graph.py\` -- v0.13.1 facade refactor (CRITICAL)
- \`src/ogham/tools/memory.py\` -- v0.13.1 \`suggest_connections\` refactor
- \`src/ogham/tools/wiki.py\`, \`src/ogham/tools/stats.py\` -- already on public, sync for parity
- \`tests/test_hooks_cli.py\` -- PR #43 added (only \`test_hooks.py\` was synced)
- \`tests/test_supabase_lifecycle_graph_parity.py\` -- v0.13.1 regression suite
- \`docs/internals/hooks.md\` -- PR #43 added

## Migrations now globbed

- \`sql/migrations/[0-9]*.sql\` -- numbered migrations from dev
- \`sql/migrations/rollback/*.sql\` -- DANGER rollback files

The migration sync is **additive**: it never deletes public-only files (public has 008a + 016 that dev archived). Re-copying immutable migration files is a no-op.

## Why this matters now

Without this fix, running \`make sync\` for v0.13.1 would silently ship broken code -- public main would still have the v0.13.0 \`lifecycle.py\` calling \`_execute\`, and Hotfix A would not actually be on PyPI.

## Test plan

- [x] \`make -n sync\` parses cleanly (Make recipe syntax valid)
- [x] Pre-commit hooks pass (prek, ruff, pyright)
- [x] Verified the 8 missing files exist in dev and would land on public after sync
- [ ] Live-fire the new sync as part of v0.13.1 release ship (this PR enables that test)