### PR TITLE
build(publish-check): bloat audit + smoke test in release path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,8 +140,54 @@ publish-check:
 		exit 1; \
 	fi
 	@echo "  ✓ No credential-like strings in dist/"
+	@echo ""
+	@echo "=== Bloat-check: sdist file count + forbidden paths ==="
+	@TMPDIR=$$(mktemp -d); \
+	SDIST=$$(ls -t dist/*.tar.gz 2>/dev/null | head -1); \
+	tar -xzf "$$SDIST" -C "$$TMPDIR"; \
+	ROOT=$$(ls -d "$$TMPDIR"/*/ | head -1); \
+	FILE_COUNT=$$(find "$$ROOT" -type f | wc -l | tr -d ' '); \
+	echo "  Files in sdist: $$FILE_COUNT"; \
+	if [ $$FILE_COUNT -lt 100 ]; then \
+		echo "❌ Publish blocked: sdist has fewer than 100 files ($$FILE_COUNT) -- something likely got over-excluded."; \
+		rm -rf "$$TMPDIR"; exit 1; \
+	fi; \
+	if [ $$FILE_COUNT -gt 400 ]; then \
+		echo "❌ Publish blocked: sdist has more than 400 files ($$FILE_COUNT) -- bloat or unintended directory shipped."; \
+		echo "   v0.13.0 baseline was 185 files. Recent good ships: 185-200 files."; \
+		echo "   Top 20 directories by file count:"; \
+		(cd "$$ROOT" && find . -type f | sed 's|^\./||; s|/[^/]*$$||' | sort | uniq -c | sort -rn | head -20 | sed 's/^/    /'); \
+		rm -rf "$$TMPDIR"; exit 1; \
+	fi; \
+	echo "  ✓ File count in expected range (100-400)"; \
+	FORBIDDEN=$$(find "$$ROOT" -type f \( \
+		-path '*/docs/*' -o \
+		-path '*/benchmarks/*' -o \
+		-path '*/.claude/*' -o \
+		-path '*/.github/*' -o \
+		-path '*/.worktrees/*' -o \
+		-path '*/research/*' -o \
+		-path '*/extras/*' -o \
+		-path '*/notebooks/*' -o \
+		-path '*/demo-scripts/*' -o \
+		-path '*/sql/migrations/rollback/*' -o \
+		-name '*.env' -o \
+		-name '*.env.local' -o \
+		-name '*.env.*.local' -o \
+		-name 'DANGER_*.sql' -o \
+		-name 'config.toml' \
+	\) 2>/dev/null | head -20); \
+	if [ -n "$$FORBIDDEN" ]; then \
+		echo "❌ Publish blocked: forbidden paths in sdist:"; \
+		echo "$$FORBIDDEN" | sed "s|$$ROOT|    |"; \
+		echo ""; \
+		echo "   These directories should be in [tool.hatch.build.targets.sdist].exclude."; \
+		rm -rf "$$TMPDIR"; exit 1; \
+	fi; \
+	echo "  ✓ No forbidden paths (docs/, benchmarks/, .claude/, .github/, demo-scripts/, rollback/, .env*, DANGER_*.sql)"; \
+	rm -rf "$$TMPDIR"
 
-publish: build publish-check
+publish: build publish-check smoke
 	@echo "=== Publishing to PyPI ==="
 	uv publish --token $$(op read "op://Ogham-Gateway/PyPi - Ogham Dev token/api_key")
 	@echo ""


### PR DESCRIPTION
v0.13.1 ship audit checklist surfaced two missing pre-publish guards. Adding both to harden the release path.

## 1. Bloat audit in \`publish-check\`

Two new checks before \`uv publish\`:

**File-count sanity.** v0.13.0 baseline was 185 sdist files; recent good ships are 185-200. Block publish if count is <100 (over-excluded -- something critical missing) or >400 (bloat / unintended directory shipped). On bloat trip, prints top 20 directories by file count for fast diagnosis.

**Forbidden path audit.** Block publish if the sdist contains files under any of:
- \`docs/\`, \`benchmarks/\`, \`.claude/\`, \`.github/\`, \`.worktrees/\`, \`research/\`, \`extras/\`, \`notebooks/\`
- \`demo-scripts/\` (the v0.13.0 1-file leak)
- \`sql/migrations/rollback/\` (DANGER rollbacks must never ship to PyPI)
- \`*.env*\`, \`DANGER_*.sql\`, \`config.toml\`

These are either dev-only or destructive (rollbacks would let a self-hoster accidentally drop production functions).

## 2. \`publish\` now depends on \`smoke\`

Was: \`publish: build publish-check\`. Now: \`publish: build publish-check smoke\`.

\`make smoke\` already exists -- installs the built wheel into a fresh venv and validates 13 module imports + the \`ogham\` CLI entrypoint. Catches the v0.4.0 class of bug where wrong content lands in dist/ before it reaches PyPI.

## Why this matters

These guards close three classes of past failure at the build-system level instead of patching per-release:
- **v0.10.x credential leak** -- existing secret scan + new bloat audit.
- **v0.11.0 sdist allowlist drift** (29 leaked paths) -- forbidden-path audit catches.
- **v0.13.0 demo-scripts/README.md leak** -- explicit \`demo-scripts/\` block in forbidden paths.

## Test plan

- [x] \`make -n publish-check\` parses cleanly
- [x] Pre-commit hooks pass (prek, ruff, pyright)
- [ ] Live-fire as part of v0.13.1 release ship (this PR enables that test)