### PR TITLE
feat: explicit recall/inscribe controls (rebased over v0.13.1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 #   - uv for Python builds
 #   - psycopg installed (for migrations)
 
-.PHONY: test lint build publish tag clean wheel sync gateway migrate release release-patch check-clean version-check smoke preflight
+.PHONY: test test-postgres-db test-postgres test-external lint build publish tag clean wheel sync gateway migrate release release-patch check-clean version-check smoke preflight
 
 # --- Paths ---
 DEV_REPO := /Users/kevinburns/Developer/web-projects/openbrain-sharedmemory
@@ -25,9 +25,20 @@ GATEWAY_REPO := /Users/kevinburns/Developer/web-projects/ogham-gateway
 
 # --- Core targets ---
 
-# Run all tests
+# Run the standard local suite. External Supabase/Ollama tests are opt-in.
 test:
 	uv run pytest tests/ -v
+
+test-postgres-db:
+	docker compose --profile test up -d postgres-scratch
+
+test-postgres: test-postgres-db
+	DATABASE_BACKEND=postgres \
+	DATABASE_URL=postgresql://ogham:ogham@localhost:5433/ogham_scratch \
+	uv run pytest -m postgres_integration
+
+test-external:
+	OGHAM_RUN_EXTERNAL_INTEGRATION=1 uv run pytest -m integration -v
 
 # Lint + format check
 lint:

--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ When `profiles` is set, results include memories from all listed profiles with a
 | `DEFAULT_MATCH_THRESHOLD` | No | `0.7` | Similarity threshold (see below) |
 | `DEFAULT_MATCH_COUNT` | No | `10` | Max results per search |
 | `DEFAULT_PROFILE` | No | `default` | Memory profile name |
+| `OGHAM_RECALL_ENABLED` | No | `true` | Enable memory recall/context retrieval |
+| `OGHAM_INSCRIBE_ENABLED` | No | `true` | Enable memory capture/content writes |
 
 ### Embedding providers
 
@@ -331,6 +333,35 @@ ogham hooks install
 
 - **recall** -- read from the stone. Searches Ogham for memories relevant to your project and injects them as context. Fires at session start and after compaction.
 - **inscribe** -- carve into the stone. Captures meaningful tool activity as memories. Skips noise (`ls`, `cat`, `git status`) and only stores signal (commits, deploys, errors, config changes). Fires after tool use and before compaction. Secrets are masked before storing.
+
+Disable either flow when you want an agent attached to Ogham without letting it pull memory into context or write new memory:
+
+```bash
+OGHAM_RECALL_ENABLED=false ogham serve       # no context injection / memory search
+OGHAM_INSCRIBE_ENABLED=false ogham serve     # no memory capture / content writes
+ogham hooks recall --no-recall               # one-off hook recall skip
+ogham hooks inscribe --no-inscribe           # one-off hook capture skip
+ogham search "query" --no-recall             # one-off CLI search skip
+ogham store "some fact" --no-inscribe        # one-off CLI store skip
+```
+
+For MCP clients, put the env vars in that client's Ogham server config:
+
+```json
+{
+  "mcpServers": {
+    "ogham": {
+      "command": "ogham-serve",
+      "env": {
+        "OGHAM_RECALL_ENABLED": "false",
+        "OGHAM_INSCRIBE_ENABLED": "false"
+      }
+    }
+  }
+}
+```
+
+Admin operations such as config, health, stats, audit, export, delete, and cleanup remain available so you can inspect or clean memory even when recall or inscribe is disabled.
 
 **Smart filtering:** Hooks don't capture everything. Routine commands (`ls`, `pwd`, `git add`) are skipped. Only signal events (errors, deployments, commits, config changes) are stored -- typically 20-30 memories per session instead of hundreds.
 
@@ -535,6 +566,39 @@ Ogham works with Supabase or vanilla PostgreSQL. Run the schema file that matche
 Supabase and Neon both include pgvector out of the box -- no extra setup needed. If you're self-hosting Postgres, you need PostgreSQL 15+ with the [pgvector](https://github.com/pgvector/pgvector) extension installed. We develop and test against PostgreSQL 17.
 
 For Postgres, set `DATABASE_BACKEND=postgres` and `DATABASE_URL=postgresql://...` in your environment.
+
+### Local pgvector test database
+
+Postgres integration tests are intentionally scratch-only. They run real
+memory rows through PostgreSQL + pgvector, but skip unless `DATABASE_URL`
+contains `scratch` or `OGHAM_TEST_ALLOW_DESTRUCTIVE=1` is set. This keeps
+ordinary `pytest` runs from touching a personal or production Ogham database.
+
+Start the standard local scratch database:
+
+```bash
+make test-postgres-db
+
+export DATABASE_BACKEND=postgres
+export DATABASE_URL=postgresql://ogham:ogham@localhost:5433/ogham_scratch
+
+uv run pytest -m postgres_integration
+# or:
+make test-postgres
+```
+
+The test harness applies the canonical `sql/schema_postgres.sql` to an empty
+scratch database, and reapplies the idempotent baseline migrations needed by
+current tests on older scratch databases.
+
+External Supabase + Ollama integration tests are opt-in so local test runs do
+not block on network services during collection:
+
+```bash
+OGHAM_RUN_EXTERNAL_INTEGRATION=1 uv run pytest -m integration -v
+# or:
+make test-external
+```
 
 ### Upgrading an existing Ogham database
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,18 @@ services:
     # Reach host Ollama from inside the container
     extra_hosts:
       - "host.docker.internal:host-gateway"
+
+  postgres-scratch:
+    image: pgvector/pgvector:pg17
+    profiles: ["test"]
+    environment:
+      POSTGRES_USER: ogham
+      POSTGRES_PASSWORD: ogham
+      POSTGRES_DB: ogham_scratch
+    ports:
+      - "5433:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ogham -d ogham_scratch"]
+      interval: 2s
+      timeout: 5s
+      retries: 20

--- a/docs/internals/hooks-cli.md
+++ b/docs/internals/hooks-cli.md
@@ -10,6 +10,16 @@ Typer-based CLI for managing Claude Code hooks. Commands:
 - Calls `hooks_install.install_hooks()`
 - Prints success/failure status with rich formatting
 
+### `recall`
+- Runs recall hooks for session start / post-compaction context
+- Supports `--recall/--no-recall` for one-off flow control
+- Also honours `OGHAM_RECALL_ENABLED`
+
+### `inscribe`
+- Runs inscribe hooks for post-tool capture / pre-compaction drains
+- Supports `--inscribe/--no-inscribe` for one-off flow control
+- Also honours `OGHAM_INSCRIBE_ENABLED`
+
 ### `uninstall`
 - Calls `hooks_install.uninstall_hooks()`
 - Removes all Ogham hook entries from Claude Code settings

--- a/docs/internals/hooks.md
+++ b/docs/internals/hooks.md
@@ -8,11 +8,13 @@
 - Searches ogham for memories relevant to the current project directory
 - Returns markdown with top matches for context injection
 - Used to prime the AI with project-specific knowledge at session start
+- Returns nothing when recall is disabled
 
 ### `post_tool(hook_input, profile)`
 - Called after every tool execution in a Claude Code session
 - Decides whether the tool execution is worth storing as a memory
 - Implements multi-layer filtering to avoid noise
+- No-ops when inscribe is disabled
 
 ### `user_prompt_submit(prompt, cwd, session_id, profile)`
 - Called for `UserPromptSubmit` hook events
@@ -22,11 +24,13 @@
 ### `pre_compact(session_id, cwd, profile)`
 - Drains session context to ogham before Claude Code compacts conversation
 - Stores a timestamped "session drain" marker
+- No-ops when inscribe is disabled
 
 ### `post_compact(cwd, profile, limit)`
 - Rehydrates context after compaction
 - Searches for recent decisions and work related to the project
 - Returns markdown for re-injection
+- Returns nothing when recall is disabled
 
 ## Filtering Pipeline (post_tool)
 
@@ -108,3 +112,14 @@ Hooks config is loaded from `hooks_config.yaml` (YAML file adjacent to `hooks.py
 - Git signal/noise subcommands
 - Secret detection patterns
 - Env secret key names
+
+Runtime flow controls are separate from the YAML signal filters:
+
+```bash
+OGHAM_RECALL_ENABLED=false ogham hooks recall
+OGHAM_INSCRIBE_ENABLED=false ogham hooks inscribe
+ogham hooks recall --no-recall
+ogham hooks inscribe --no-inscribe
+```
+
+Use `OGHAM_RECALL_ENABLED=false` in an MCP client config to prevent memory-derived context from reaching the LLM. Use `OGHAM_INSCRIBE_ENABLED=false` to prevent hook capture and content writes to Ogham. Admin commands remain available for inspection and cleanup.

--- a/src/ogham/backends/postgres.py
+++ b/src/ogham/backends/postgres.py
@@ -352,14 +352,10 @@ class PostgresBackend:
             f"VALUES {', '.join(values_clauses)} RETURNING *"
         )
 
-        results: list[dict[str, Any]] = []
-        with self._checkout() as conn:
-            with conn.cursor() as cur:
-                cur.execute(sql.encode(), params)
-                for result in cur.fetchall():
-                    result.pop("embedding", None)
-                    result.pop("fts", None)
-                    results.append(result)
+        results = self._execute(sql, params, fetch="all")
+        for result in results:
+            result.pop("embedding", None)
+            result.pop("fts", None)
         return results
 
     def update_memory(

--- a/src/ogham/cli.py
+++ b/src/ogham/cli.py
@@ -24,9 +24,13 @@ def _run_server(
     transport: str | None = None,
     host: str | None = None,
     port: int | None = None,
+    recall: bool | None = None,
+    inscribe: bool | None = None,
 ):
+    from ogham.flow_control import set_flow_overrides
     from ogham.server import main as server_main
 
+    set_flow_overrides(recall=recall, inscribe=inscribe)
     server_main(transport=transport, host=host, port=port)
 
 
@@ -42,9 +46,19 @@ def serve(
     transport: Optional[str] = typer.Option(None, help="Transport: stdio or sse"),
     host: Optional[str] = typer.Option(None, help="SSE bind host (default 127.0.0.1)"),
     port: Optional[int] = typer.Option(None, help="SSE port (default 8742)"),
+    recall: Optional[bool] = typer.Option(
+        None,
+        "--recall/--no-recall",
+        help="Enable or disable recall for this server process",
+    ),
+    inscribe: Optional[bool] = typer.Option(
+        None,
+        "--inscribe/--no-inscribe",
+        help="Enable or disable inscribe for this server process",
+    ),
 ):
     """Start the MCP server."""
-    _run_server(transport=transport, host=host, port=port)
+    _run_server(transport=transport, host=host, port=port, recall=recall, inscribe=inscribe)
 
 
 @app.command()
@@ -55,8 +69,42 @@ def store(
     tags_csv: Optional[str] = typer.Option(None, "--tags", help="Comma-separated tags"),
     source: str = typer.Option("cli", help="Source identifier"),
     output_json: bool = typer.Option(False, "--json", help="Output JSON instead of rich text"),
+    inscribe: Optional[bool] = typer.Option(
+        None,
+        "--inscribe/--no-inscribe",
+        help="Enable or disable inscribe for this command",
+    ),
 ):
     """Store a new memory."""
+    from ogham.flow_control import disabled_message, inscribe_enabled, temporary_flow_overrides
+
+    with temporary_flow_overrides(inscribe=inscribe):
+        if not inscribe_enabled():
+            if output_json:
+                print(
+                    json.dumps(
+                        {
+                            "status": "disabled",
+                            "flow": "inscribe",
+                            "message": disabled_message("inscribe"),
+                        }
+                    )
+                )
+            else:
+                console.print(f"[yellow]{disabled_message('inscribe')}[/yellow]")
+            return
+
+        _store_impl(content, profile, tags, tags_csv, source, output_json)
+
+
+def _store_impl(
+    content: str,
+    profile: str | None,
+    tags: list[str] | None,
+    tags_csv: str | None,
+    source: str,
+    output_json: bool,
+) -> None:
     from ogham.config import settings
     from ogham.service import store_memory_enriched
 
@@ -220,8 +268,35 @@ def search(
     tags_csv: Optional[str] = typer.Option(None, "--tags", help="Comma-separated tags"),
     output_json: bool = typer.Option(False, "--json", help="Output JSON instead of rich table"),
     extract: bool = typer.Option(False, "--extract", help="Extract query-relevant facts via LLM"),
+    recall: Optional[bool] = typer.Option(
+        None,
+        "--recall/--no-recall",
+        help="Enable or disable recall for this command",
+    ),
 ):
     """Search memories by meaning and keywords (hybrid search)."""
+    from ogham.flow_control import disabled_message, recall_enabled, temporary_flow_overrides
+
+    with temporary_flow_overrides(recall=recall):
+        if not recall_enabled():
+            if output_json:
+                print("[]")
+            else:
+                console.print(f"[yellow]{disabled_message('recall')}[/yellow]")
+            return
+
+        _search_impl(query, limit, profile, tags, tags_csv, output_json, extract)
+
+
+def _search_impl(
+    query: str,
+    limit: int,
+    profile: str | None,
+    tags: list[str] | None,
+    tags_csv: str | None,
+    output_json: bool,
+    extract: bool,
+) -> None:
     from ogham.config import settings
 
     merged_tags = list(tags or [])
@@ -475,6 +550,12 @@ def import_cmd(
     dedup: float = typer.Option(0.8, help="Dedup threshold (0 to disable)"),
 ):
     """Import memories from a JSON export file."""
+    from ogham.flow_control import disabled_message, inscribe_enabled
+
+    if not inscribe_enabled():
+        console.print(f"[yellow]{disabled_message('inscribe')}[/yellow]")
+        return
+
     from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn, TimeRemainingColumn
 
     from ogham.config import settings

--- a/src/ogham/config.py
+++ b/src/ogham/config.py
@@ -121,6 +121,9 @@ class Settings(BaseSettings):
     server_host: str = Field(default="127.0.0.1", validation_alias="OGHAM_HOST")
     server_port: int = Field(default=8742, validation_alias="OGHAM_PORT")
 
+    recall_enabled: bool = Field(default=True, validation_alias="OGHAM_RECALL_ENABLED")
+    inscribe_enabled: bool = Field(default=True, validation_alias="OGHAM_INSCRIBE_ENABLED")
+
     gateway_url: str = Field(default="", validation_alias="OGHAM_GATEWAY_URL")
     gateway_api_key: str = Field(default="", validation_alias="OGHAM_API_KEY")
 

--- a/src/ogham/flow_control.py
+++ b/src/ogham/flow_control.py
@@ -1,0 +1,88 @@
+"""Runtime controls for Ogham recall and inscribe flows."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+_recall_override: bool | None = None
+_inscribe_override: bool | None = None
+
+
+def set_flow_overrides(
+    *,
+    recall: bool | None = None,
+    inscribe: bool | None = None,
+) -> None:
+    """Set process-local overrides for CLI/server entrypoints."""
+    global _recall_override, _inscribe_override
+    if recall is not None:
+        _recall_override = recall
+    if inscribe is not None:
+        _inscribe_override = inscribe
+
+
+def clear_flow_overrides() -> None:
+    """Clear process-local overrides. Used by tests."""
+    global _recall_override, _inscribe_override
+    _recall_override = None
+    _inscribe_override = None
+
+
+@contextmanager
+def temporary_flow_overrides(
+    *,
+    recall: bool | None = None,
+    inscribe: bool | None = None,
+) -> Iterator[None]:
+    """Apply overrides for one command and restore the previous process state."""
+    global _recall_override, _inscribe_override
+    old_recall = _recall_override
+    old_inscribe = _inscribe_override
+    set_flow_overrides(recall=recall, inscribe=inscribe)
+    try:
+        yield
+    finally:
+        _recall_override = old_recall
+        _inscribe_override = old_inscribe
+
+
+def recall_enabled() -> bool:
+    if _recall_override is not None:
+        return _recall_override
+    from ogham.config import settings
+
+    return bool(getattr(settings, "recall_enabled", True))
+
+
+def inscribe_enabled() -> bool:
+    if _inscribe_override is not None:
+        return _inscribe_override
+    from ogham.config import settings
+
+    return bool(getattr(settings, "inscribe_enabled", True))
+
+
+def disabled_message(flow: str) -> str:
+    if flow == "recall":
+        return "Recall is disabled for this Ogham process."
+    if flow == "inscribe":
+        return "Inscribe is disabled for this Ogham process."
+    return f"{flow} is disabled for this Ogham process."
+
+
+def disabled_payload(flow: str, **extra: Any) -> dict[str, Any]:
+    return {
+        "status": "disabled",
+        "flow": flow,
+        "message": disabled_message(flow),
+        **extra,
+    }
+
+
+def flow_status() -> dict[str, bool]:
+    return {
+        "recall_enabled": recall_enabled(),
+        "inscribe_enabled": inscribe_enabled(),
+    }

--- a/src/ogham/hooks.py
+++ b/src/ogham/hooks.py
@@ -865,6 +865,11 @@ def session_start(
     schedules a lifecycle advancement sweep on the background executor.
     The sweep is fire-and-forget -- session starts even if it fails.
     """
+    from ogham.flow_control import recall_enabled
+
+    if not recall_enabled():
+        return ""
+
     from ogham.database import hybrid_search_memories
     from ogham.embeddings import generate_embedding
 
@@ -940,6 +945,11 @@ def post_tool(
 
     Skips Ogham's own tools to prevent infinite loops.
     """
+    from ogham.flow_control import inscribe_enabled
+
+    if not inscribe_enabled():
+        return
+
     tool_name = str(hook_input.get("tool_name", ""))
 
     # Skip Ogham's own tools (infinite loop prevention)
@@ -1059,6 +1069,11 @@ def pre_compact(
     dry_run: bool = False,
 ) -> str | None:
     """Drain session context to Ogham before compaction."""
+    from ogham.flow_control import inscribe_enabled
+
+    if not inscribe_enabled():
+        return
+
     project_name = os.path.basename(cwd)
     timestamp = datetime.now(timezone.utc).isoformat()
 
@@ -1096,6 +1111,11 @@ def post_compact(
 
     Returns markdown with the most relevant memories for the project.
     """
+    from ogham.flow_control import recall_enabled
+
+    if not recall_enabled():
+        return ""
+
     from ogham.database import hybrid_search_memories
     from ogham.embeddings import generate_embedding
 

--- a/src/ogham/hooks_cli.py
+++ b/src/ogham/hooks_cli.py
@@ -86,27 +86,42 @@ def _echo_dry_run(result: str | None) -> None:
 def recall_cmd(
     profile: str = typer.Option("work", help="Memory profile"),
     force: bool = typer.Option(False, help="Skip debounce, always recall"),
+    recall: bool | None = typer.Option(
+        None,
+        "--recall/--no-recall",
+        help="Enable or disable recall for this hook invocation",
+    ),
 ):
     """Read from the stone. Load relevant memories for the current project."""
+    from ogham.flow_control import recall_enabled, temporary_flow_overrides
     from ogham.hooks import post_compact, session_start
 
-    # Debounce: only recall once per 30 min (Kiro fires on every prompt)
-    if not force and not _should_recall():
-        return
+    with temporary_flow_overrides(recall=recall):
+        if not recall_enabled():
+            return
 
-    data = _read_stdin()
-    cwd = data.get("cwd", ".")
+        # Debounce: only recall once per 30 min (Kiro fires on every prompt)
+        if not force and not _should_recall():
+            return
 
-    output = session_start(cwd=cwd, profile=profile)
-    if not output:
-        output = post_compact(cwd=cwd, profile=profile)
-    if output:
-        typer.echo(output)
+        data = _read_stdin()
+        cwd = data.get("cwd", ".")
+
+        output = session_start(cwd=cwd, profile=profile)
+        if not output:
+            output = post_compact(cwd=cwd, profile=profile)
+        if output:
+            typer.echo(output)
 
 
 @hooks_app.command(name="inscribe")
 def inscribe_cmd(
     profile: str = typer.Option("work", help="Memory profile"),
+    inscribe: bool | None = typer.Option(
+        None,
+        "--inscribe/--no-inscribe",
+        help="Enable or disable inscribe for this hook invocation",
+    ),
     dry_run: bool = typer.Option(
         False,
         "--dry-run",
@@ -114,47 +129,52 @@ def inscribe_cmd(
     ),
 ):
     """Carve into the stone. Capture activity or drain session before compaction."""
+    from ogham.flow_control import inscribe_enabled, temporary_flow_overrides
     from ogham.hooks import post_tool, pre_compact, user_prompt_submit
 
-    data = _read_stdin()
+    with temporary_flow_overrides(inscribe=inscribe):
+        if not inscribe_enabled():
+            return
 
-    if not data:
-        # Kiro Agent Stop or no stdin -- create a minimal marker
-        import os
+        data = _read_stdin()
 
-        data = {
-            "tool_name": "AgentStop",
-            "tool_input": {"summary": "Agent turn completed"},
-            "cwd": os.getcwd(),
-            "session_id": "kiro",
-        }
+        if not data:
+            # Kiro Agent Stop or no stdin -- create a minimal marker
+            import os
 
-    event = _event_type(data)
+            data = {
+                "tool_name": "AgentStop",
+                "tool_input": {"summary": "Agent turn completed"},
+                "cwd": os.getcwd(),
+                "session_id": "kiro",
+            }
 
-    if event == "UserPromptSubmit":
-        result = user_prompt_submit(
-            prompt=_prompt_from_data(data),
-            cwd=data.get("cwd", "."),
-            session_id=data.get("session_id", "unknown"),
-            profile=profile,
-            dry_run=dry_run,
-        )
-        if dry_run:
-            _echo_dry_run(result)
-    elif "tool_name" in data:
-        result = post_tool(data, profile=profile, dry_run=dry_run)
-        if dry_run:
-            _echo_dry_run(result)
-    else:
-        # Otherwise treat as compaction drain
-        result = pre_compact(
-            session_id=data.get("session_id", "unknown"),
-            cwd=data.get("cwd", "."),
-            profile=profile,
-            dry_run=dry_run,
-        )
-        if dry_run:
-            _echo_dry_run(result)
+        event = _event_type(data)
+
+        if event == "UserPromptSubmit":
+            result = user_prompt_submit(
+                prompt=_prompt_from_data(data),
+                cwd=data.get("cwd", "."),
+                session_id=data.get("session_id", "unknown"),
+                profile=profile,
+                dry_run=dry_run,
+            )
+            if dry_run:
+                _echo_dry_run(result)
+        elif "tool_name" in data:
+            result = post_tool(data, profile=profile, dry_run=dry_run)
+            if dry_run:
+                _echo_dry_run(result)
+        else:
+            # Otherwise treat as compaction drain
+            result = pre_compact(
+                session_id=data.get("session_id", "unknown"),
+                cwd=data.get("cwd", "."),
+                profile=profile,
+                dry_run=dry_run,
+            )
+            if dry_run:
+                _echo_dry_run(result)
 
 
 @hooks_app.command(name="install")

--- a/src/ogham/prompts.py
+++ b/src/ogham/prompts.py
@@ -16,6 +16,11 @@ from ogham.tools.memory import get_active_profile
 @mcp.prompt()
 def summarize_recent(limit: int = 10) -> str:
     """Summarize recent memories in the active profile."""
+    from ogham.flow_control import disabled_message, recall_enabled
+
+    if not recall_enabled():
+        return disabled_message("recall")
+
     profile = get_active_profile()
     memories = list_recent_memories(profile=profile, limit=limit)
 
@@ -35,6 +40,11 @@ def summarize_recent(limit: int = 10) -> str:
 @mcp.prompt()
 def find_decisions(topic: str) -> str:
     """Find decisions made about a specific topic."""
+    from ogham.flow_control import disabled_message, recall_enabled
+
+    if not recall_enabled():
+        return disabled_message("recall")
+
     profile = get_active_profile()
     query = f"decision about {topic}"
     embedding = generate_embedding(query)
@@ -60,6 +70,11 @@ def find_decisions(topic: str) -> str:
 @mcp.prompt()
 def profile_overview() -> str:
     """Show an overview of the active memory profile."""
+    from ogham.flow_control import disabled_message, recall_enabled
+
+    if not recall_enabled():
+        return disabled_message("recall")
+
     profile = get_active_profile()
     stats = get_memory_stats(profile=profile)
     recent = list_recent_memories(profile=profile, limit=5)

--- a/src/ogham/service.py
+++ b/src/ogham/service.py
@@ -208,6 +208,11 @@ def store_memory_enriched(
 
     Returns the stored memory dict with id, created_at, links_created, etc.
     """
+    from ogham.flow_control import disabled_payload, inscribe_enabled
+
+    if not inscribe_enabled():
+        return disabled_payload("inscribe", profile=profile)
+
     # Lazy import to avoid circular dependency with tools/memory.py
     from ogham.tools.memory import _require_content
 
@@ -492,6 +497,11 @@ def search_memories_enriched(
             extract query-relevant facts. Returns a single extracted-facts
             result instead of raw memories. Default: False (verbatim results).
     """
+    from ogham.flow_control import recall_enabled
+
+    if not recall_enabled():
+        return []
+
     embedding_usage: EmbeddingUsage | None = None
 
     if embedding is None:

--- a/src/ogham/tools/memory.py
+++ b/src/ogham/tools/memory.py
@@ -230,10 +230,15 @@ def store_memory(
         metadata: Additional structured data to store alongside the memory.
         auto_link: Automatically link to similar existing memories (default True).
     """
+    from ogham.flow_control import disabled_payload, inscribe_enabled
+
+    active_profile = get_active_profile()
+    if not inscribe_enabled():
+        return disabled_payload("inscribe", profile=active_profile)
+
     from ogham.recompute_executor import enqueue_for_tags
     from ogham.service import store_memory_enriched
 
-    active_profile = get_active_profile()
     result = store_memory_enriched(
         content=content,
         profile=active_profile,
@@ -303,6 +308,8 @@ def store_decision(
         tags=decision_tags,
         metadata=metadata,
     )
+    if result.get("status") == "disabled":
+        return result
 
     if related_memories:
         for rel_id in related_memories:
@@ -536,6 +543,15 @@ def hybrid_search(
                   with v0.12 runs; 'short' is the typical-cost default.
     """
     _require_limit(limit)
+    from ogham.flow_control import disabled_payload, recall_enabled
+
+    if not recall_enabled():
+        return {
+            **disabled_payload("recall"),
+            "results": [],
+            "wiki_preamble": [],
+        }
+
     from ogham.embeddings import generate_embedding
     from ogham.service import _wiki_injection_results, search_memories_enriched
 
@@ -573,6 +589,11 @@ def list_recent(
         tags: Filter to memories with any of these tags.
     """
     _require_limit(limit)
+    from ogham.flow_control import recall_enabled
+
+    if not recall_enabled():
+        return []
+
     return list_recent_memories(
         profile=get_active_profile(),
         limit=limit,
@@ -628,6 +649,11 @@ def update_memory(
         tags: New tags (replaces existing tags).
         metadata: New metadata (replaces existing metadata).
     """
+    from ogham.flow_control import disabled_payload, inscribe_enabled
+
+    if not inscribe_enabled():
+        return disabled_payload("inscribe", id=memory_id, profile=get_active_profile())
+
     updates: dict[str, Any] = {}
     if content is not None:
         updates["content"] = content
@@ -681,6 +707,11 @@ def reinforce_memory(
         memory_id: The UUID of the memory to reinforce.
         strength: How strongly to reinforce (0.5-1.0, default 0.85). Higher = stronger boost.
     """
+    from ogham.flow_control import disabled_payload, inscribe_enabled
+
+    if not inscribe_enabled():
+        return disabled_payload("inscribe", id=memory_id, profile=get_active_profile())
+
     if not 0.0 < strength <= 1.0:
         raise ValueError(f"strength must be between 0.0 (exclusive) and 1.0, got {strength}")
     from ogham.database import get_memory_by_id
@@ -719,6 +750,11 @@ def contradict_memory(
         memory_id: The UUID of the memory to contradict.
         strength: How strongly to contradict (0.0-0.5, default 0.15). Lower = stronger.
     """
+    from ogham.flow_control import disabled_payload, inscribe_enabled
+
+    if not inscribe_enabled():
+        return disabled_payload("inscribe", id=memory_id, profile=get_active_profile())
+
     if not 0.0 <= strength < 1.0:
         raise ValueError(f"strength must be between 0.0 and 1.0 (exclusive), got {strength}")
     from ogham.database import get_memory_by_id
@@ -850,6 +886,11 @@ def import_memories_tool(data: str, dedup_threshold: float = 0.8) -> dict[str, A
         data: JSON string from a previous export_profile call.
         dedup_threshold: Skip memories with similarity above this (0 to disable dedup).
     """
+    from ogham.flow_control import disabled_payload, inscribe_enabled
+
+    if not inscribe_enabled():
+        return disabled_payload("inscribe", profile=get_active_profile())
+
     return _import_memories(data, profile=get_active_profile(), dedup_threshold=dedup_threshold)
 
 
@@ -924,6 +965,11 @@ def explore_knowledge(
         source: Filter seed results to memories from this source.
     """
     _require_limit(limit)
+    from ogham.flow_control import recall_enabled
+
+    if not recall_enabled():
+        return []
+
     embedding = generate_embedding(query)
     results = db_explore_graph(
         query_text=query,
@@ -961,6 +1007,11 @@ def find_related(
         min_strength: Minimum edge strength to follow (default 0.5).
         limit: Maximum results to return (default 20).
     """
+    from ogham.flow_control import recall_enabled
+
+    if not recall_enabled():
+        return []
+
     return db_get_related(
         memory_id=memory_id,
         depth=depth,
@@ -988,6 +1039,11 @@ def suggest_connections(
         min_shared_entities: Minimum entities in common (default 2).
         limit: Maximum suggestions (default 10).
     """
+    from ogham.flow_control import recall_enabled
+
+    if not recall_enabled():
+        return []
+
     from ogham.database import get_backend
 
     # v0.13.1: route through facade so Supabase works (was raising

--- a/src/ogham/tools/stats.py
+++ b/src/ogham/tools/stats.py
@@ -63,6 +63,10 @@ def get_runtime_config() -> dict[str, Any]:
         },
     }
 
+    from ogham.flow_control import flow_status
+
+    config["memory_flows"] = flow_status()
+
     # Database-specific fields
     if settings.database_backend == "supabase":
         config["database"]["supabase_url"] = settings.supabase_url

--- a/src/ogham/tools/wiki.py
+++ b/src/ogham/tools/wiki.py
@@ -156,7 +156,11 @@ def compile_wiki(
         memories carry this tag in the active profile, returns
         `{"status": "no_sources", ...}` without writing anything.
     """
+    from ogham.flow_control import disabled_payload, inscribe_enabled
+
     profile = get_active_profile()
+    if not inscribe_enabled():
+        return disabled_payload("inscribe", topic_key=topic, profile=profile)
 
     # `force=True` is implemented by marking the existing summary stale
     # before recompute. The recompute pipeline's short-circuit checks
@@ -241,6 +245,18 @@ def walk_knowledge(
         edge_strength, connected_from (parent in the path), and the
         direction the edge was followed.
     """
+    from ogham.flow_control import disabled_payload, recall_enabled
+
+    if not recall_enabled():
+        return disabled_payload(
+            "recall",
+            start_id=start_id,
+            depth=depth,
+            direction=direction,
+            node_count=0,
+            nodes=[],
+        )
+
     if direction not in _VALID_DIRECTIONS:
         return {
             "status": "error",
@@ -317,7 +333,13 @@ def query_topic_summary(topic: str, level: LevelType = "body") -> dict[str, Any]
     """
     if level not in _LEVEL_TO_COLUMN:
         raise ValueError(f"unknown level {level!r}; expected one of {sorted(_LEVEL_TO_COLUMN)}")
+
+    from ogham.flow_control import disabled_payload, recall_enabled
+
     profile = get_active_profile()
+    if not recall_enabled():
+        return disabled_payload("recall", topic_key=topic, profile=profile)
+
     summary = get_summary_by_topic(profile, topic)
     if summary is None:
         return {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,34 @@ from typing import Any, cast
 import pytest
 
 
+def _truthy_env(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in ("1", "true", "yes")
+
+
+def pytest_configure(config):
+    """Default local collection to hermetic unit-test config.
+
+    Several legacy integration modules perform reachability checks at import
+    time, before autouse fixtures can isolate environment variables. If a
+    developer's local Ogham config points at Postgres, ordinary ``pytest`` can
+    spend minutes trying to connect to that database during collection. Keep
+    default local runs hermetic, while preserving explicit scratch Postgres and
+    external Supabase/Ollama opt-in paths.
+    """
+    if _truthy_env("OGHAM_RUN_EXTERNAL_INTEGRATION") or _truthy_env("OGHAM_TEST_ALLOW_DESTRUCTIVE"):
+        return
+
+    url = os.environ.get("DATABASE_URL", "")
+    if "scratch" in url.lower():
+        return
+
+    os.environ.setdefault("DATABASE_BACKEND", "supabase")
+    os.environ.setdefault("SUPABASE_URL", "https://fake.supabase.co")
+    os.environ.setdefault("SUPABASE_KEY", "fake-key")
+    os.environ.setdefault("EMBEDDING_PROVIDER", "ollama")
+    os.environ.setdefault("DEFAULT_PROFILE", "default")
+
+
 def _destructive_db_safe() -> tuple[bool, str]:
     """Return (allowed, reason). Guard for fixtures that DROP / DELETE.
 
@@ -15,7 +43,7 @@ def _destructive_db_safe() -> tuple[bool, str]:
     Protects against accidentally running the lifecycle test fixtures
     against a prod / demo DB and wiping triggers, columns, or rows.
     """
-    if os.environ.get("OGHAM_TEST_ALLOW_DESTRUCTIVE", "").strip().lower() in ("1", "true", "yes"):
+    if _truthy_env("OGHAM_TEST_ALLOW_DESTRUCTIVE"):
         return True, "OGHAM_TEST_ALLOW_DESTRUCTIVE set"
     url = os.environ.get("DATABASE_URL", "")
     if "scratch" in url.lower():
@@ -27,12 +55,45 @@ def _destructive_db_safe() -> tuple[bool, str]:
     )
 
 
+def _postgres_integration_db_safe() -> tuple[bool, str]:
+    """Return whether live Postgres integration tests may run.
+
+    Unlike unit tests, postgres integration tests use the configured
+    ``Settings`` object so a developer's ~/.ogham/config.env is visible.
+    We still require a scratch database name/URL, or explicit opt-in, so
+    `pytest` never exercises a personal/prod Ogham database by accident.
+    """
+    if _truthy_env("OGHAM_TEST_ALLOW_DESTRUCTIVE"):
+        return True, "OGHAM_TEST_ALLOW_DESTRUCTIVE set"
+
+    url = os.environ.get("DATABASE_URL", "")
+    if not url:
+        try:
+            from ogham.config import settings
+
+            url = settings.database_url or ""
+        except Exception:
+            url = ""
+
+    if "scratch" in url.lower():
+        return True, "database URL contains 'scratch'"
+    return (
+        False,
+        f"Postgres integration tests require a scratch DATABASE_URL; got {url!r}",
+    )
+
+
 @pytest.fixture(autouse=True)
 def _isolated_unit_environment(monkeypatch, request):
     """Keep unit tests independent from a developer's local Ogham env."""
     is_external_integration = request.node.get_closest_marker(
         "integration"
     ) or request.node.get_closest_marker("postgres_integration")
+
+    if request.node.get_closest_marker("postgres_integration"):
+        allowed, reason = _postgres_integration_db_safe()
+        if not allowed:
+            pytest.skip(reason)
 
     if not is_external_integration:
         monkeypatch.setenv("DATABASE_BACKEND", "supabase")
@@ -52,14 +113,14 @@ def _isolated_unit_environment(monkeypatch, request):
 
 
 @pytest.fixture(scope="session", autouse=True)
-def _apply_lifecycle_migrations():
-    """Ensure lifecycle schema exists on the scratch DB for the run.
+def _ensure_standard_postgres_test_schema():
+    """Ensure scratch Postgres has the standard pgvector test schema.
 
-    Migrations 025 + 026 are both idempotent. We apply them once per
-    test session in order: 025 adds memories.stage columns, then 026
-    moves lifecycle state into ``memory_lifecycle`` (dropping the
-    memories columns). After this fixture runs, the scratch DB is in the
-    post-026 state.
+    Local Postgres integration tests should run against a predictable
+    scratch database, not whatever schema happens to live in a developer's
+    personal Ogham DB. For an empty scratch DB, apply schema_postgres.sql.
+    For an older scratch DB, apply the small idempotent baseline migrations
+    needed by current tests.
 
     The ``pg_fresh_db`` fixture drops everything on teardown; tests that
     use it re-apply the migrations explicitly -- so even though this
@@ -71,7 +132,7 @@ def _apply_lifecycle_migrations():
 
         if settings.database_backend != "postgres":
             return
-        allowed, reason = _destructive_db_safe()
+        allowed, reason = _postgres_integration_db_safe()
         if not allowed:
             # Session-scope fixture can't skip individual tests; just no-op
             # and let per-test guards handle the skip with a clear reason.
@@ -79,6 +140,22 @@ def _apply_lifecycle_migrations():
         from ogham.backends.postgres import PostgresBackend
 
         backend = PostgresBackend()
+        repo_root = Path(__file__).parent.parent
+
+        tables = backend._execute(
+            "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'",
+            fetch="all",
+        )
+        table_names = {str(r["table_name"]) for r in tables}
+        if "memories" not in table_names:
+            schema = repo_root / "sql/schema_postgres.sql"
+            backend._execute(schema.read_text(), fetch="none")
+            return
+
+        # Current profile stats tests require migration 022's additive
+        # relationship/tagging/decay counters.
+        mig_022 = repo_root / "sql/migrations/022_profile_health_stats.sql"
+        backend._execute(mig_022.read_text(), fetch="none")
 
         # Has 026 been applied? (i.e. memory_lifecycle exists)
         tables = backend._execute(
@@ -96,11 +173,11 @@ def _apply_lifecycle_migrations():
         )
         col_names = {str(r["column_name"]) for r in cols}
         if "stage" not in col_names:
-            mig_025 = Path(__file__).parent.parent / "sql/migrations/025_memory_lifecycle.sql"
+            mig_025 = repo_root / "sql/migrations/025_memory_lifecycle.sql"
             backend._execute(mig_025.read_text(), fetch="none")
 
         # Apply 026.
-        mig_026 = Path(__file__).parent.parent / "sql/migrations/026_memory_lifecycle_split.sql"
+        mig_026 = repo_root / "sql/migrations/026_memory_lifecycle_split.sql"
         backend._execute(mig_026.read_text(), fetch="none")
     except Exception:
         # Tests that need the columns will still skip via _can_connect

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,10 +8,15 @@ runner = CliRunner()
 
 @pytest.fixture(autouse=True)
 def mock_settings(monkeypatch):
+    from ogham.flow_control import clear_flow_overrides
+
+    clear_flow_overrides()
     monkeypatch.setenv("SUPABASE_URL", "https://fake.supabase.co")
     monkeypatch.setenv("SUPABASE_KEY", "fake-key")
     monkeypatch.setenv("EMBEDDING_PROVIDER", "ollama")
     monkeypatch.setenv("DEFAULT_PROFILE", "default")
+    yield
+    clear_flow_overrides()
 
 
 def test_cli_health():
@@ -28,6 +33,18 @@ def test_cli_health():
 
     assert result.exit_code == 0
     assert "ok" in result.output.lower()
+
+
+def test_cli_config_shows_memory_flow_controls():
+    """ogham config should expose effective recall/inscribe state."""
+    from ogham.cli import app
+
+    result = runner.invoke(app, ["config", "--json"])
+
+    assert result.exit_code == 0
+    assert '"memory_flows"' in result.output
+    assert '"recall_enabled": true' in result.output
+    assert '"inscribe_enabled": true' in result.output
 
 
 def test_cli_profiles():
@@ -85,6 +102,22 @@ def test_cli_search():
 
     assert result.exit_code == 0
     assert "test memory" in result.output
+
+
+def test_cli_search_no_recall_skips_search():
+    """ogham search --no-recall should not embed or search."""
+    from ogham.cli import app
+
+    with (
+        patch("ogham.embeddings.generate_embedding") as mock_embed,
+        patch("ogham.database.hybrid_search_memories") as mock_search,
+    ):
+        result = runner.invoke(app, ["search", "test query", "--no-recall"])
+
+    assert result.exit_code == 0
+    assert "Recall is disabled" in result.output
+    mock_embed.assert_not_called()
+    mock_search.assert_not_called()
 
 
 def test_cli_list():
@@ -175,6 +208,18 @@ def test_cli_store():
     assert call_kwargs["source"] == "cli"
 
 
+def test_cli_store_no_inscribe_skips_store():
+    """ogham store --no-inscribe should not call the store pipeline."""
+    from ogham.cli import app
+
+    with patch("ogham.service.store_memory_enriched") as mock_store:
+        result = runner.invoke(app, ["store", "test memory content here", "--no-inscribe"])
+
+    assert result.exit_code == 0
+    assert "Inscribe is disabled" in result.output
+    mock_store.assert_not_called()
+
+
 def test_cli_store_with_ttl():
     """ogham store should show expiry when profile has TTL"""
     from ogham.cli import app
@@ -229,6 +274,23 @@ def test_cli_serve():
 
     assert result.exit_code == 0
     mock_main.assert_called_once_with(transport=None, host=None, port=None)
+
+
+def test_cli_serve_flow_overrides():
+    """ogham serve should apply recall/inscribe overrides for the server process."""
+    from ogham.cli import app
+    from ogham.flow_control import flow_status
+
+    captured = {}
+
+    def fake_main(**_kwargs):
+        captured.update(flow_status())
+
+    with patch("ogham.server.main", side_effect=fake_main):
+        result = runner.invoke(app, ["serve", "--no-recall", "--no-inscribe"])
+
+    assert result.exit_code == 0
+    assert captured == {"recall_enabled": False, "inscribe_enabled": False}
 
 
 def test_cli_serve_sse():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,13 @@ import pytest
 @pytest.fixture(autouse=True)
 def clean_ogham_env(monkeypatch):
     """Clear OGHAM_ transport env vars before each test."""
-    for key in ("OGHAM_TRANSPORT", "OGHAM_HOST", "OGHAM_PORT"):
+    for key in (
+        "OGHAM_TRANSPORT",
+        "OGHAM_HOST",
+        "OGHAM_PORT",
+        "OGHAM_RECALL_ENABLED",
+        "OGHAM_INSCRIBE_ENABLED",
+    ):
         monkeypatch.delenv(key, raising=False)
 
 
@@ -21,6 +27,8 @@ def test_transport_defaults(monkeypatch):
     assert s.server_transport == "stdio"
     assert s.server_host == "127.0.0.1"
     assert s.server_port == 8742
+    assert s.recall_enabled is True
+    assert s.inscribe_enabled is True
 
 
 def test_transport_env_override(monkeypatch):
@@ -42,6 +50,45 @@ def test_transport_env_override(monkeypatch):
 def test_transport_invalid_rejected(monkeypatch):
     """Invalid transport value raises ValueError."""
     monkeypatch.setenv("OGHAM_TRANSPORT", "websocket")
+    monkeypatch.setenv("SUPABASE_URL", "https://fake.supabase.co")
+    monkeypatch.setenv("SUPABASE_KEY", "fake")
+
+    from ogham.config import Settings
+
+    with pytest.raises(Exception):
+        Settings()
+
+
+def test_flow_control_env_defaults(monkeypatch):
+    """Recall/inscribe controls default to enabled."""
+    monkeypatch.setenv("SUPABASE_URL", "https://fake.supabase.co")
+    monkeypatch.setenv("SUPABASE_KEY", "fake")
+
+    from ogham.config import Settings
+
+    s = Settings()
+    assert s.recall_enabled is True
+    assert s.inscribe_enabled is True
+
+
+@pytest.mark.parametrize("value", ["false", "0", "no", "off"])
+def test_flow_control_env_false_values(monkeypatch, value):
+    """Common false spellings disable recall and inscribe."""
+    monkeypatch.setenv("OGHAM_RECALL_ENABLED", value)
+    monkeypatch.setenv("OGHAM_INSCRIBE_ENABLED", value)
+    monkeypatch.setenv("SUPABASE_URL", "https://fake.supabase.co")
+    monkeypatch.setenv("SUPABASE_KEY", "fake")
+
+    from ogham.config import Settings
+
+    s = Settings()
+    assert s.recall_enabled is False
+    assert s.inscribe_enabled is False
+
+
+def test_flow_control_invalid_bool_rejected(monkeypatch):
+    """Invalid bool config is rejected by Pydantic."""
+    monkeypatch.setenv("OGHAM_RECALL_ENABLED", "sometimes")
     monkeypatch.setenv("SUPABASE_URL", "https://fake.supabase.co")
     monkeypatch.setenv("SUPABASE_KEY", "fake")
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -8,10 +8,13 @@ import pytest
 @pytest.fixture(autouse=True)
 def _clear_dedup_cache():
     """Clear the dedup cache between tests."""
+    from ogham.flow_control import clear_flow_overrides
     from ogham.hooks import _recent_actions
 
+    clear_flow_overrides()
     _recent_actions.clear()
     yield
+    clear_flow_overrides()
     _recent_actions.clear()
 
 
@@ -56,6 +59,24 @@ def test_session_start_empty_db():
     assert result == ""
 
 
+def test_session_start_disabled_skips_recall_side_effects():
+    from ogham.flow_control import temporary_flow_overrides
+    from ogham.hooks import session_start
+
+    with temporary_flow_overrides(recall=False):
+        with (
+            patch("ogham.database.hybrid_search_memories") as search,
+            patch("ogham.embeddings.generate_embedding") as embed,
+            patch("ogham.hooks.lifecycle_submit") as lifecycle,
+        ):
+            result = session_start(cwd="/Users/dev/myproject", profile="work")
+
+    assert result == ""
+    search.assert_not_called()
+    embed.assert_not_called()
+    lifecycle.assert_not_called()
+
+
 def test_post_tool_stores_action():
     from ogham.hooks import post_tool
 
@@ -71,6 +92,23 @@ def test_post_tool_stores_action():
     mock_store.assert_called_once()
     content = mock_store.call_args.kwargs["content"]
     assert "git commit: fix: update config" in content
+
+
+def test_post_tool_disabled_skips_store():
+    from ogham.flow_control import temporary_flow_overrides
+    from ogham.hooks import post_tool
+
+    hook_input = {
+        "tool_name": "Bash",
+        "tool_input": {"command": "git commit -m 'fix: update config'"},
+        "session_id": "abc123",
+        "cwd": "/Users/dev/myproject",
+    }
+    with temporary_flow_overrides(inscribe=False):
+        with patch("ogham.service.store_memory_enriched") as mock_store:
+            post_tool(hook_input, profile="work")
+
+    mock_store.assert_not_called()
 
 
 def test_post_tool_skips_ogham_tools():
@@ -668,6 +706,17 @@ def test_pre_compact_stores_summary():
     assert "compaction:drain" in tags
 
 
+def test_pre_compact_disabled_skips_store():
+    from ogham.flow_control import temporary_flow_overrides
+    from ogham.hooks import pre_compact
+
+    with temporary_flow_overrides(inscribe=False):
+        with patch("ogham.service.store_memory_enriched") as mock_store:
+            pre_compact(session_id="abc", cwd="/Users/dev/myproject", profile="work")
+
+    mock_store.assert_not_called()
+
+
 def test_post_compact_returns_context():
     from ogham.hooks import post_compact
 
@@ -700,6 +749,22 @@ def test_post_compact_empty_db():
         result = post_compact(cwd="/tmp/empty", profile="work")
 
     assert result == ""
+
+
+def test_post_compact_disabled_skips_recall():
+    from ogham.flow_control import temporary_flow_overrides
+    from ogham.hooks import post_compact
+
+    with temporary_flow_overrides(recall=False):
+        with (
+            patch("ogham.database.hybrid_search_memories") as search,
+            patch("ogham.embeddings.generate_embedding") as embed,
+        ):
+            result = post_compact(cwd="/Users/dev/myproject", profile="work")
+
+    assert result == ""
+    search.assert_not_called()
+    embed.assert_not_called()
 
 
 def test_session_start_handles_errors():

--- a/tests/test_hooks_cli.py
+++ b/tests/test_hooks_cli.py
@@ -2,9 +2,19 @@
 
 from unittest.mock import patch
 
+import pytest
 from typer.testing import CliRunner
 
 runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def clear_flow_overrides():
+    from ogham.flow_control import clear_flow_overrides
+
+    clear_flow_overrides()
+    yield
+    clear_flow_overrides()
 
 
 def test_hooks_inscribe_dry_run_previews_tool_memory():
@@ -56,3 +66,32 @@ def test_hooks_inscribe_dry_run_reports_skipped_memory():
 
     assert result.exit_code == 0
     assert "No memory would be stored." in result.output
+
+
+def test_hooks_recall_no_recall_skips_hooks():
+    from ogham.hooks_cli import hooks_app
+
+    with (
+        patch("ogham.hooks.session_start") as session_start,
+        patch("ogham.hooks.post_compact") as post_compact,
+        patch("ogham.hooks_cli._should_recall", return_value=True),
+    ):
+        result = runner.invoke(hooks_app, ["recall", "--no-recall"])
+
+    assert result.exit_code == 0
+    session_start.assert_not_called()
+    post_compact.assert_not_called()
+
+
+def test_hooks_inscribe_no_inscribe_skips_hooks():
+    from ogham.hooks_cli import hooks_app
+
+    with (
+        patch("ogham.hooks.post_tool") as post_tool,
+        patch("ogham.hooks.pre_compact") as pre_compact,
+    ):
+        result = runner.invoke(hooks_app, ["inscribe", "--no-inscribe"])
+
+    assert result.exit_code == 0
+    post_tool.assert_not_called()
+    pre_compact.assert_not_called()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,11 +1,13 @@
 """Integration tests against real Supabase + Ollama.
 
-Run with: uv run pytest tests/test_integration.py -v
+Run with: OGHAM_RUN_EXTERNAL_INTEGRATION=1 uv run pytest tests/test_integration.py -v
 Skip with: uv run pytest -m 'not integration'
 
 Uses a dedicated '_test_integration' profile to avoid polluting real data.
 All test memories are cleaned up in the teardown fixture.
 """
+
+import os
 
 import pytest
 
@@ -14,6 +16,12 @@ TEST_PROFILE = "_test_integration"
 
 def _can_connect() -> bool:
     """Check if Supabase and Ollama are reachable."""
+    if os.environ.get("OGHAM_RUN_EXTERNAL_INTEGRATION", "").strip().lower() not in (
+        "1",
+        "true",
+        "yes",
+    ):
+        return False
     try:
         from ogham.database import get_client
 

--- a/tests/test_lifecycle_parity.py
+++ b/tests/test_lifecycle_parity.py
@@ -8,13 +8,16 @@ columns returning defaults (stage='fresh', stage_entered_at=created_at).
 from __future__ import annotations
 
 import json
+import os
 import subprocess
+from pathlib import Path
 
 import pytest
 
 from ogham.service import store_memory_enriched
 
-GO_BIN = "/Users/kevinburns/Developer/web-projects/ogham-cli/ogham"
+DEFAULT_GO_BIN = Path("/Users/kevinburns/Developer/web-projects/ogham-cli/ogham")
+GO_BIN = os.environ.get("OGHAM_GO_BIN") or (str(DEFAULT_GO_BIN) if DEFAULT_GO_BIN.exists() else "")
 
 
 def _can_connect() -> bool:
@@ -36,6 +39,7 @@ def _can_connect() -> bool:
 pytestmark = [
     pytest.mark.postgres_integration,
     pytest.mark.skipif(not _can_connect(), reason="Postgres backend not configured or unreachable"),
+    pytest.mark.skipif(not GO_BIN, reason="Go Ogham CLI unavailable; set OGHAM_GO_BIN"),
 ]
 
 

--- a/tests/test_postgres_batch_ingest.py
+++ b/tests/test_postgres_batch_ingest.py
@@ -93,47 +93,15 @@ def test_store_memories_batch_does_one_execute_not_n(pg_fresh_db):
 
     insert_calls: list[str] = []
 
-    class CountingCursor:
-        """Wraps a real cursor; records any execute whose SQL inserts into memories.
+    real_execute = PostgresBackend._execute
 
-        Pool checkout runs SET search_path / housekeeping SELECTs -- those
-        don't count toward the N+1 contract. Only INSERTs into the memories
-        table do.
-        """
+    def wrapped_execute(self, sql, *a, **kw):
+        sql_str = str(sql).strip().upper()
+        if sql_str.startswith("INSERT INTO MEMORIES"):
+            insert_calls.append(str(sql))
+        return real_execute(self, sql, *a, **kw)
 
-        def __init__(self, inner):
-            self._inner = inner
-
-        def __enter__(self):
-            self._inner.__enter__()
-            return self
-
-        def __exit__(self, *a):
-            return self._inner.__exit__(*a)
-
-        def execute(self, sql, *a, **kw):
-            sql_str = str(sql).strip().upper()
-            if sql_str.startswith("INSERT INTO MEMORIES"):
-                insert_calls.append(str(sql))
-            return self._inner.execute(sql, *a, **kw)
-
-        def fetchone(self):
-            return self._inner.fetchone()
-
-        def fetchall(self):
-            return self._inner.fetchall()
-
-        def __getattr__(self, name):
-            return getattr(self._inner, name)
-
-    import psycopg
-
-    real_connect_cursor = psycopg.Connection.cursor
-
-    def wrapped_cursor(self, *a, **kw):
-        return CountingCursor(real_connect_cursor(self, *a, **kw))
-
-    with patch.object(psycopg.Connection, "cursor", wrapped_cursor):
+    with patch.object(PostgresBackend, "_execute", wrapped_execute):
         backend.store_memories_batch(rows)
 
     assert len(insert_calls) == 1, (

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -8,6 +8,9 @@ FAKE_ID = "a1b2c3d4-0000-0000-0000-000000000001"
 
 @pytest.fixture(autouse=True)
 def mock_settings(monkeypatch):
+    from ogham.flow_control import clear_flow_overrides
+
+    clear_flow_overrides()
     monkeypatch.setenv("SUPABASE_URL", "https://fake.supabase.co")
     monkeypatch.setenv("SUPABASE_KEY", "fake-key")
     monkeypatch.setenv("EMBEDDING_PROVIDER", "ollama")
@@ -15,6 +18,8 @@ def mock_settings(monkeypatch):
     # Tests assume the resolution order falls through to settings.default_profile
     # = "default". The OGHAM_PROFILE env var would short-circuit that.
     monkeypatch.delenv("OGHAM_PROFILE", raising=False)
+    yield
+    clear_flow_overrides()
 
 
 @pytest.fixture(autouse=True)
@@ -177,6 +182,20 @@ def test_store_memory_uses_active_profile(mock_embedding, mock_db):
     assert call_kwargs["profile"] == "personal"
 
 
+def test_store_memory_disabled_does_not_store_or_enqueue(mock_embedding, mock_db):
+    from ogham.flow_control import temporary_flow_overrides
+    from ogham.tools.memory import store_memory
+
+    with temporary_flow_overrides(inscribe=False):
+        result = store_memory(content="test memory", source="test", tags=["tag1"])
+
+    assert result["status"] == "disabled"
+    assert result["flow"] == "inscribe"
+    mock_embedding.assert_not_called()
+    mock_db["store"].assert_not_called()
+    mock_db["enqueue"].assert_not_called()
+
+
 def test_hybrid_search(mock_embedding, mock_db):
     """v0.12.1 split shape: hybrid_search returns dict with results +
     wiki_preamble keys. wiki_preamble defaults to [] when injection is
@@ -197,6 +216,22 @@ def test_hybrid_search(mock_embedding, mock_db):
     assert call_kwargs["query_text"] == "test query"
     assert call_kwargs["profile"] == "default"
     mock_db["record_access"].assert_called_once_with([FAKE_ID])
+
+
+def test_hybrid_search_disabled_does_not_recall(mock_embedding, mock_db):
+    from ogham.flow_control import temporary_flow_overrides
+    from ogham.tools.memory import hybrid_search
+
+    with temporary_flow_overrides(recall=False):
+        out = hybrid_search(query="test query")
+
+    assert out["status"] == "disabled"
+    assert out["flow"] == "recall"
+    assert out["results"] == []
+    assert out["wiki_preamble"] == []
+    mock_embedding.assert_not_called()
+    mock_db["search"].assert_not_called()
+    mock_db["record_access"].assert_not_called()
 
 
 def test_list_recent(mock_embedding, mock_db):
@@ -1259,6 +1294,30 @@ def test_store_decision_with_related_memories(mock_embedding, mock_db):
         created_by="user",
         metadata={},
     )
+
+
+def test_store_decision_disabled_with_related_memories_does_not_create_edges(
+    mock_embedding, mock_db
+):
+    """Disabled inscribe should short-circuit before supports edges use result['id']."""
+    from ogham.flow_control import temporary_flow_overrides
+    from ogham.tools.memory import store_decision
+
+    related_id = "b2c3d4e5-0000-0000-0000-000000000002"
+
+    with temporary_flow_overrides(inscribe=False):
+        with patch("ogham.tools.memory.db_create_relationship") as mock_rel:
+            result = store_decision(
+                decision="Use RRF for hybrid search",
+                rationale="No score normalization needed",
+                related_memories=[related_id],
+            )
+
+    assert result["status"] == "disabled"
+    assert result["flow"] == "inscribe"
+    mock_embedding.assert_not_called()
+    mock_db["store"].assert_not_called()
+    mock_rel.assert_not_called()
 
 
 # --- get_related_memories database tests ---


### PR DESCRIPTION
Cherry-picks @ersahinco's [PR #42](https://github.com/ogham-mcp/ogham-mcp/pull/42) onto post-v0.13.1 main. Same 25 files, same +873/-114 LOC, authored as Cemre. Cemre is busy on a Microsoft Agent Framework POC; this picks up the v0.14 headline so we don't block on his cycle.

## Summary

- Adds `src/ogham/flow_control.py` with explicit `recall_enabled` / `inscribe_enabled` flow gates + `temporary_flow_overrides` context manager
- Wires `--recall/--no-recall` and `--inscribe/--no-inscribe` flags into `ogham hooks recall` and `ogham hooks inscribe`
- Updates `service.py` and `tools/memory.py` to gate ingest paths through `inscribe_enabled()`
- New tests for both gate paths

## Conflict resolution against v0.13.1

Two conflicts hand-resolved:

**`src/ogham/hooks_cli.py`** — both PR #42 (`--inscribe/--no-inscribe`) and v0.13.1 PR #43 (`--dry-run` + smart inscribe) reshaped the `inscribe_cmd` function. Merged so both flags coexist: the `temporary_flow_overrides(inscribe=...)` wrapper from PR #42 wraps the `_event_type` routing + dry-run handling from PR #43. New event branch `UserPromptSubmit` and Kiro `AgentStop` fallback both preserved.

**`tests/test_hooks_cli.py`** — both branches added the file fresh. Merged so all 5 tests run: 3 from PR #43 (dry-run preview, dry-run UserPromptSubmit, dry-run skip) + 2 from PR #42 (no-recall skip, no-inscribe skip). Single `clear_flow_overrides` autouse fixture from PR #42.

## Verification

- 754/754 unit tests pass
- Pre-commit hooks (ruff, pyright, security) all green
- `flow_control.py` integrates with Hotfix A's lifecycle/graph backend facade methods (no new conflicts there)

## Why a parallel PR

Cemre granted maintainer-edit perms on PR #42, but he's mid-POC on AWS / Microsoft Agent Framework. This parallel PR avoids force-pushing to his branch while keeping the v0.14 headline unblocked. Original PR #42 stays open for him to close when convenient.

## Closes

- Supersedes #42 (parallel rebase)
- Headlines v0.14 per the locked gameplan ("memory hygiene + ingestion control")